### PR TITLE
analysis/type_inference: improve the complexity of nested_exp_list

### DIFF
--- a/src/analysis/type_inference.ml
+++ b/src/analysis/type_inference.ml
@@ -234,22 +234,21 @@ let type_info_tag = Value.Tag.register (module TypeInfo)
 
 (** returns a list with all nested expressions. If expr1 is contained in expr2, then
     expr1 will be included after expr2 in the list. *)
-let rec nested_exp_list exp : Exp.t list =
-  let nested_exp = match exp with
-    | Bil.Load(exp1, exp2, _, _) -> exp :: (nested_exp_list exp1) @ (nested_exp_list exp2)
-    | Bil.Store(exp1, exp2, exp3, _, _) -> nested_exp_list exp1 @ nested_exp_list exp2 @ nested_exp_list exp3
-    | Bil.BinOp(_op, exp1, exp2) -> nested_exp_list exp1 @ nested_exp_list exp2
-    | Bil.UnOp(_op, exp1) -> nested_exp_list exp1
-    | Bil.Var(_) -> []
-    | Bil.Int(_) -> []
-    | Bil.Cast(_, _, exp1) -> nested_exp_list exp1
-    | Bil.Let(_, exp1, exp2) -> nested_exp_list exp1 @ nested_exp_list exp2
-    | Bil.Unknown(_) -> []
-    | Bil.Ite(exp1, exp2, exp3) -> nested_exp_list exp1 @ nested_exp_list exp2 @ nested_exp_list exp3
-    | Bil.Extract(_, _, exp1) -> nested_exp_list exp1
-    | Bil.Concat(exp1, exp2) -> nested_exp_list exp1 @ nested_exp_list exp2 in
-  exp :: nested_exp
-
+let nested_exp_list exp : Exp.t list =
+  let rec nested_exp_list exp acc = exp :: match exp with
+    | Bil.Load(exp1, exp2, _, _) -> nested_exp_list exp1 @@ nested_exp_list exp2 acc
+    | Bil.Store(exp1, exp2, exp3, _, _) -> nested_exp_list exp1 @@ nested_exp_list exp2 @@ nested_exp_list exp3 acc
+    | Bil.BinOp(_op, exp1, exp2) -> nested_exp_list exp1 @@ nested_exp_list exp2 acc
+    | Bil.UnOp(_op, exp1) -> nested_exp_list exp1 acc
+    | Bil.Var(_) -> acc
+    | Bil.Int(_) -> acc
+    | Bil.Cast(_, _, exp1) -> nested_exp_list exp1 acc
+    | Bil.Let(_, exp1, exp2) -> nested_exp_list exp1 @@ nested_exp_list exp2 acc
+    | Bil.Unknown(_) -> acc
+    | Bil.Ite(exp1, exp2, exp3) -> nested_exp_list exp1 @@ nested_exp_list exp2 @@ nested_exp_list exp3 acc
+    | Bil.Extract(_, _, exp1) -> nested_exp_list exp1 acc
+    | Bil.Concat(exp1, exp2) -> nested_exp_list exp1 @@ nested_exp_list exp2 acc in
+  nested_exp_list exp []
 
 (** If exp is a load from the stack, return the corresponding element. If it may be
     a load from the stack, but could also be a load from some other memory region,


### PR DESCRIPTION
I don't know if this function is important to the overall codebase --
I see it used only once in add_mem_address_registers -- but the
previous implementation was a clear code smell; I was browsing the
code during https://2019.pass-the-salt.org/talks/74.html and I thought
that I could go fix it.

The main problem with the previous implementation is that it has
quadratic complexity for deeply-nested expressions. Consider for example:

    | Bil.Ite(exp1, exp2, exp3) ->
      nested_exp_list exp1 @ nested_exp_list exp2 @ nested_exp_list exp3

the complexity cost of the list concatenations in this sample is
proportional to the size of the result list. If you consider a deep
nesting of 'ite' constructs, you get a quadratic complexity.

The new implementation uses an accumulator; each element in the output
list has been processed exactly once, with no intermediate sub-list
built in the process, guaranteeing linear complexity.

(The function is still not tail-recursive, but that shouldn't be an
issue given that we don't expect nesting of Bil expressions to exceed
the available stack space. It would make the code slightly more
complex to make it tail-recursive.)

Note: this patch also fixes a minor bug, in the Load case the
expression was added twice to the output list, once in the Load branch
and once at the end. I think (but I am not sure) that the user of this
function is robust with respect to repeated subexpressions, so that
did not cause correctness problems.