### PR TITLE
Ghidra bugfix

### DIFF
--- a/src/checkers/cwe_248.ml
+++ b/src/checkers/cwe_248.ml
@@ -9,9 +9,9 @@ let version = "0.1"
 let print_uncatched_exception block_tid ~tid_map =
   let address = (Address_translation.translate_tid_to_assembler_address_string block_tid tid_map) in
   let description = sprintf "(Possibly Uncaught Exception) (Exception thrown at %s)." address in
-  let cwe_warning = cwe_warning_factory name version description in
+  let cwe_warning = cwe_warning_factory name version description ~addresses:[address] in
   collect_cwe_warning cwe_warning
-                    
+
 (* Extract the name of a direct call, if the block contains a direct call. *)
 let extract_direct_call_symbol block =
   match Symbol_utils.extract_direct_call_tid_from_block block with

--- a/test/acceptance/test_file_output.py
+++ b/test/acceptance/test_file_output.py
@@ -7,7 +7,7 @@ class TestFileOutput(unittest.TestCase):
 
     def setUp(self):
         self.res_file = '/tmp/res.json'
-        self.cmd = 'bap test/artificial_samples/build/cwe_190_x64.out --pass=cwe-checker --cwe-checker-config=src/config.json --cwe-checker-json --cwe-checker-out=%s' % self.res_file
+        self.cmd = 'bap test/artificial_samples/build/cwe_190_x64_gcc.out --pass=cwe-checker --cwe-checker-config=src/config.json --cwe-checker-json --cwe-checker-out=%s' % self.res_file
 
     def test_can_output_file(self):
         if 'travis' in os.environ['USER']:


### PR DESCRIPTION
This PR fixes two minor bugs and adds a workaround for the address computation of Ghidra, which sometimes adds an offset and sometimes not. There seems to be no function in the Ghidra API that can be used to tell the plugin when this happens and when not.

If the workaround does not work for you (i.e. CWEs imported via the Ghidra plugin are bookmarked at the wrong addresses), please open an issue!