### PR TITLE
Bap2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fkiecad/cwe_checker_travis_docker_image:stable
+FROM fkiecad/cwe_checker_travis_docker_image:latest
 
 COPY . /home/bap/cwe_checker/
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Another option is to pull the latest Docker image from [dockerhub](https://hub.d
 -   `docker pull fkiecad/cwe_checker:stable` yields an image based on the latest stable release version.
 
 If you plan to develop cwe_checker, it is recommended to build it using the provided `Makefile`. In this case you must ensure that all dependencies are fulfilled:
--   Ocaml 4.05.0
+-   Ocaml 4.07.1
 -   Opam 2.0.2
 -   dune >= 1.6
--   BAP 1.6 (and its dependencies)
+-   BAP (and its dependencies). Development on the master branch depends on the master branch of BAP which can be added with `opam repo add bap-testing git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing` to the sources of the Opam package manager. The stable release of the *cwe_checker* depends on BAP 1.6.
 -   yojson >= 1.6.0
 -   ppx_deriving_yojson >= 3.5.1
 -   alcotest >= 0.8.3 (for tests)

--- a/cwe_checker.opam
+++ b/cwe_checker.opam
@@ -12,10 +12,10 @@ homepage: "https://github.com/fkie-cad/cwe_checker"
 bug-reports: "https://github.com/fkie-cad/cwe_checker/issues"
 dev-repo: "git+https://github.com/fkie-cad/cwe_checker"
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.07.1"}
   "dune" {>= "1.6"}
   "yojson" {>= "1.6.0"}
-  "bap" {>= "1.6" & < "2.0"}
+  "bap" {>= "2.0"}
   "alcotest" {>= "0.8.3"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "ppx_jane" {>= "v0.11" & < "v0.12"}

--- a/src/cwe_checker_core.opam
+++ b/src/cwe_checker_core.opam
@@ -12,10 +12,10 @@ homepage: "https://github.com/fkie-cad/cwe_checker"
 bug-reports: "https://github.com/fkie-cad/cwe_checker/issues"
 dev-repo: "git+https://github.com/fkie-cad/cwe_checker"
 depends: [
-  "ocaml" {>= "4.05"}
+  "ocaml" {>= "4.07.1"}
   "dune" {>= "1.6"}
   "yojson" {>= "1.6.0"}
-  "bap" {>= "1.6" & < "2.0"}
+  "bap" {>= "2.0"}
   "core_kernel" {>= "v0.11" & < "v0.12"}
   "ppx_jane" {>= "v0.11" & < "v0.12"}
   "ppx_deriving_yojson" {>= "3.5.1"}

--- a/test/acceptance/test_cwe415.py
+++ b/test/acceptance/test_cwe415.py
@@ -30,7 +30,7 @@ class TestCwe415(unittest.TestCase):
         self.assertEqual(res, expect_res)
 
     def test_cwe415_01_x86_clang(self):
-        expect_res = 5
+        expect_res = 7
         res = cwe_checker_testlib.execute_emulation_and_check_occurence(
             self.target, self.target, 'x86', 'clang', self.string)
         self.assertEqual(res, expect_res)

--- a/test/acceptance/test_cwe416.py
+++ b/test/acceptance/test_cwe416.py
@@ -30,7 +30,7 @@ class TestCwe416(unittest.TestCase):
         self.assertEqual(res, expect_res)
 
     def test_cwe416_01_x86_clang(self):
-        expect_res = 2
+        expect_res = 3
         res = cwe_checker_testlib.execute_emulation_and_check_occurence(
             self.target, self.target, 'x86', 'clang', self.string)
         self.assertEqual(res, expect_res)

--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -1,6 +1,6 @@
 all:
 	bapbundle remove cwe_checker_unit_tests.plugin
-	bapbuild -r -Is analysis,checkers,utils cwe_checker_unit_tests.plugin -pkgs core,alcotest,yojson,unix,ppx_jane,cwe_checker_core
+	bapbuild -r -Is analysis,checkers,utils cwe_checker_unit_tests.plugin -pkgs alcotest,yojson,unix,ppx_jane,cwe_checker_core
 	bapbundle install cwe_checker_unit_tests.plugin
 	bap ../artificial_samples/build/arrays_x64_gcc.out --pass=cwe-checker-unit-tests
 	bapbundle remove cwe_checker_unit_tests.plugin

--- a/test/unit/dune
+++ b/test/unit/dune
@@ -5,8 +5,7 @@
   yojson
   bap
   cwe_checker_core
-  core_kernel
-  core)
+  core_kernel)
   (preprocess (pps ppx_jane))
 )
 


### PR DESCRIPTION
This PR updates the used BAP version to its current development version. Since we depend on a bugfix that is not yet included in the stable BAP 2.0 version, upgrading to BAP 2.0 was not enough.