### PR TITLE
Migration from travis-ci.org to travis-ci.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ services:
 install:
   - sudo apt-get update
   - pip install scons
-  - docker
 
 before_script:
   - ./.travis_prepare.sh

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # cwe_checker #
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/9dbf158110de427d893b40ba397b94bc)](https://www.codacy.com/app/weidenba/cwe_checker?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=fkie-cad/cwe_checker&amp;utm_campaign=Badge_Grade)
-[![Build Status](https://travis-ci.org/fkie-cad/cwe_checker.svg?branch=master)](https://travis-ci.org/fkie-cad/cwe_checker)
+[![Build Status](https://travis-ci.com/fkie-cad/cwe_checker.svg?branch=master)](https://travis-ci.com/fkie-cad/cwe_checker)
 ![Docker-Pulls](https://img.shields.io/docker/pulls/fkiecad/cwe_checker.svg)
 [![Documentation](https://img.shields.io/badge/doc-stable-green.svg)](https://fkie-cad.github.io/cwe_checker/doc/html/cwe_checker/index.html)
 ## What is cwe_checker? ##


### PR DESCRIPTION
Migrated to travis-ci.org so that Travis build results are again displayed on pull requests.