### PR TITLE
Fix return

### DIFF
--- a/cwe_checker_rs/src/analysis/graph.rs
+++ b/cwe_checker_rs/src/analysis/graph.rs
@@ -180,6 +180,9 @@ impl<'a> GraphBuilder<'a> {
         return_from_sub: &Term<Sub>,
         return_source: NodeIndex,
     ) {
+        if self.return_addresses.get(&return_from_sub.tid).is_none() {
+            return;
+        }
         for (call_node, return_to_node) in self.return_addresses[&return_from_sub.tid].iter() {
             let call_block = self.graph[*call_node].get_block();
             let call_term = call_block

--- a/cwe_checker_rs/src/analysis/pointer_inference/context.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/context.rs
@@ -204,7 +204,7 @@ impl<'a> crate::analysis::interprocedural_fixpoint::Problem<'a> for Context<'a> 
                 callee_state.set_register(
                     &self.project.stack_pointer_register,
                     super::data::PointerDomain::new(
-                        callee_stack_id,
+                        callee_stack_id.clone(),
                         Bitvector::zero(apint::BitWidth::new(address_bitsize as usize).unwrap())
                             .into(),
                     )
@@ -213,10 +213,14 @@ impl<'a> crate::analysis::interprocedural_fixpoint::Problem<'a> for Context<'a> 
                 Some(&call_term.tid),
             );
             // set the list of caller stack ids to only this caller id
-            callee_state.caller_ids = BTreeSet::new();
-            callee_state.caller_ids.insert(new_caller_stack_id.clone());
-            // remove non-referenced objects from the state
+            callee_state.caller_stack_ids = BTreeSet::new();
+            callee_state.caller_stack_ids.insert(new_caller_stack_id.clone());
+            // Remove non-referenced objects and objects, only the caller knows about, from the state.
+            callee_state.ids_known_to_caller = BTreeSet::new();
             callee_state.remove_unreferenced_objects();
+            // all remaining objects, except for the callee stack id, are also known to the caller
+            callee_state.ids_known_to_caller = callee_state.memory.get_all_object_ids();
+            callee_state.ids_known_to_caller.remove(&callee_stack_id);
 
             return callee_state;
         } else {
@@ -231,6 +235,11 @@ impl<'a> crate::analysis::interprocedural_fixpoint::Problem<'a> for Context<'a> 
         state_before_call: Option<&State>,
         call_term: &Term<Jmp>,
     ) -> Option<State> {
+        // TODO: For the long term we may have to replace the IDs representing callers with something
+        // that identifies the edge of the call and not just the callsite.
+        // When indirect calls are handled, the callsite alone is not a unique identifier anymore.
+        // This may lead to confusion if both caller and callee have the same ID in their respective caller_stack_id sets.
+
         // we only return to functions with a value before the call to prevent returning to dead code
         let state_before_call = match state_before_call {
             Some(value) => value,
@@ -244,8 +253,17 @@ impl<'a> crate::analysis::interprocedural_fixpoint::Problem<'a> for Context<'a> 
         let callee_stack_id = &state_before_return.stack_id;
         let stack_offset_on_call = self.get_current_stack_offset(state_before_call);
 
+        // Check whether state_before_return actually knows the caller_stack_id.
+        // If not, we are returning from a state that cannot correspond to this callsite.
+        if !state_before_return.caller_stack_ids.contains(&caller_stack_id) {
+            return None;
+        }
+
         let mut state_after_return = state_before_return.clone();
         state_after_return.remove_virtual_register();
+        // Remove the IDs of other callers not corresponding to this call
+        state_after_return.remove_other_caller_stack_ids(&caller_stack_id);
+
         state_after_return.replace_abstract_id(
             &caller_stack_id,
             original_caller_stack_id,
@@ -257,7 +275,11 @@ impl<'a> crate::analysis::interprocedural_fixpoint::Problem<'a> for Context<'a> 
             &(-stack_offset_on_call.clone()),
         );
         state_after_return.stack_id = original_caller_stack_id.clone();
-        state_after_return.caller_ids = state_before_call.caller_ids.clone();
+        state_after_return.caller_stack_ids = state_before_call.caller_stack_ids.clone();
+        state_after_return.ids_known_to_caller = state_before_call.ids_known_to_caller.clone();
+
+        state_after_return.readd_caller_objects(state_before_call);
+
         // remove non-referenced objects from the state
         state_after_return.remove_unreferenced_objects();
 
@@ -518,6 +540,21 @@ mod tests {
         }
     }
 
+    fn reg_add_term(name: &str, value: i64, tid_name: &str) -> Term<Def> {
+        let add_expr = Expression::BinOp{
+            op: crate::bil::BinOpType::PLUS,
+            lhs: Box::new(Expression::Var(register(name))),
+            rhs: Box::new(Expression::Const(Bitvector::from_i64(value))),
+        };
+        Term {
+            tid: Tid::new(format!("{}", tid_name)),
+            term: Def {
+                lhs: register(name),
+                rhs: add_expr,
+            }
+        }
+    }
+
     fn call_term(target_name: &str) -> Term<Jmp> {
         let call = Call {
             target: Label::Direct(Tid::new(target_name)),
@@ -611,9 +648,9 @@ mod tests {
         let call = call_term("func");
         let mut callee_state = context.update_call(&state, &call, &target_node);
         assert_eq!(callee_state.stack_id, new_id("func", "RSP"));
-        assert_eq!(callee_state.caller_ids.len(), 1);
+        assert_eq!(callee_state.caller_stack_ids.len(), 1);
         assert_eq!(
-            callee_state.caller_ids.iter().next().unwrap(),
+            callee_state.caller_stack_ids.iter().next().unwrap(),
             &new_id("call_func", "RSP")
         );
 
@@ -628,7 +665,7 @@ mod tests {
             .update_return(&callee_state, Some(&state), &call)
             .unwrap();
         assert_eq!(return_state.stack_id, new_id("main", "RSP"));
-        assert_eq!(return_state.caller_ids, BTreeSet::new());
+        assert_eq!(return_state.caller_stack_ids, BTreeSet::new());
         assert_eq!(
             return_state.memory.get_internal_id_map(),
             state.memory.get_internal_id_map()
@@ -721,5 +758,43 @@ mod tests {
             .get_register(&register("other_reg"))
             .unwrap()
             .is_top());
+    }
+
+    #[test]
+    fn update_return() {
+        use crate::analysis::interprocedural_fixpoint::Problem;
+        use crate::analysis::pointer_inference::object::ObjectType;
+        use crate::analysis::pointer_inference::data::*;
+        let project = mock_project();
+        let (cwe_sender, _cwe_receiver) = crossbeam_channel::unbounded();
+        let (log_sender, _log_receiver) = crossbeam_channel::unbounded();
+        let context = Context::new(&project, cwe_sender, log_sender);
+        let state_before_return = State::new(&register("RSP"), Tid::new("callee"));
+        let mut state_before_return = context.update_def(&state_before_return, &reg_add_term("RSP", 8, "stack_offset_on_return_adjustment"));
+
+        let callsite_id = new_id("call_callee", "RSP");
+        state_before_return.memory.add_abstract_object(callsite_id.clone(), bv(0).into(), ObjectType::Stack, 64);
+        state_before_return.caller_stack_ids.insert(callsite_id.clone());
+        state_before_return.ids_known_to_caller.insert(callsite_id.clone());
+
+        let other_callsite_id = new_id("call_callee_other", "RSP");
+        state_before_return.memory.add_abstract_object(other_callsite_id.clone(), bv(0).into(), ObjectType::Stack, 64);
+        state_before_return.caller_stack_ids.insert(other_callsite_id.clone());
+        state_before_return.ids_known_to_caller.insert(other_callsite_id.clone());
+        state_before_return.set_register(&register("RAX"), Data::Pointer(PointerDomain::new(new_id("call_callee_other", "RSP"), bv(-32)))).unwrap();
+
+        let state_before_call = State::new(&register("RSP"), Tid::new("original_caller_id"));
+        let state_before_call = context.update_def(&state_before_call, &reg_add_term("RSP", -16, "stack_offset_on_call_adjustment"));
+
+        let state = context.update_return(&state_before_return, Some(&state_before_call), &call_term("callee")).unwrap();
+
+        assert_eq!(state.ids_known_to_caller, BTreeSet::new());
+        assert_eq!(state.caller_stack_ids, BTreeSet::new());
+        assert_eq!(state.stack_id, new_id("original_caller_id", "RSP"));
+        assert!(state.memory.get_all_object_ids().len() == 1);
+        assert!(state.memory.get_all_object_ids().get(&new_id("original_caller_id", "RSP")).is_some());
+        assert!(state.get_register(&register("RSP")).is_ok());
+        let expected_rsp = Data::Pointer(PointerDomain::new(new_id("original_caller_id", "RSP"), bv(-8)));
+        assert_eq!(state.get_register(&register("RSP")).unwrap(), expected_rsp);
     }
 }

--- a/cwe_checker_rs/src/analysis/pointer_inference/data.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/data.rs
@@ -39,6 +39,8 @@ impl Data {
         }
     }
 
+    /// If *self* is a pointer, remove all provided IDs from the target list of it.
+    /// If this would leave the pointer without any targets, replace it with Data::Top(..).
     pub fn remove_ids(&mut self, ids_to_remove: &BTreeSet<AbstractIdentifier>) {
         // TODO: Some callers don't want to get Top(..) values. Probably has to be handled at the respective callsites.
         if let Data::Pointer(pointer) = self {

--- a/cwe_checker_rs/src/analysis/pointer_inference/data.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/data.rs
@@ -38,6 +38,24 @@ impl Data {
             BTreeSet::new()
         }
     }
+
+    pub fn remove_ids(&mut self, ids_to_remove: &BTreeSet<AbstractIdentifier>) {
+        // TODO: Some callers don't want to get Top(..) values. Probably has to be handled at the respective callsites.
+        if let Data::Pointer(pointer) = self {
+            let remaining_targets: BTreeMap<AbstractIdentifier, BitvectorDomain> = pointer.iter_targets().filter_map(|(id, offset)| {
+                if ids_to_remove.get(id).is_none() {
+                    Some((id.clone(), offset.clone()))
+                } else {
+                    None
+                }
+            }).collect();
+            if remaining_targets.len() == 0 {
+                *self = Data::new_top(self.bitsize());
+            } else {
+                *self = Data::Pointer(PointerDomain::with_targets(remaining_targets));
+            }
+        }
+    }
 }
 
 impl Data {

--- a/cwe_checker_rs/src/analysis/pointer_inference/object.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/object.rs
@@ -109,6 +109,18 @@ impl AbstractObject {
         }
     }
 
+    pub fn remove_ids(&mut self, ids_to_remove: &BTreeSet<AbstractIdentifier>) {
+        match self {
+            Self::Untracked(targets) => {
+                let remaining_targets = targets.difference(ids_to_remove).cloned().collect();
+                *self = Self::Untracked(remaining_targets);
+            }
+            Self::Memory(mem) => {
+                mem.remove_ids(ids_to_remove);
+            }
+        }
+    }
+
     #[cfg(test)]
     pub fn get_state(&self) -> Option<ObjectState> {
         match self {
@@ -236,6 +248,13 @@ impl AbstractObjectInfo {
             if self.state != new_state {
                 self.state = None;
             } // else don't change the state
+        }
+    }
+
+    pub fn remove_ids(&mut self, ids_to_remove: &BTreeSet<AbstractIdentifier>) {
+        self.pointer_targets = self.pointer_targets.difference(ids_to_remove).cloned().collect();
+        for value in self.memory.iter_values_mut() {
+            value.remove_ids(ids_to_remove);
         }
     }
 }

--- a/cwe_checker_rs/src/analysis/pointer_inference/object.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/object.rs
@@ -109,6 +109,7 @@ impl AbstractObject {
         }
     }
 
+    /// Remove the provided IDs from all possible target lists, including all pointers.
     pub fn remove_ids(&mut self, ids_to_remove: &BTreeSet<AbstractIdentifier>) {
         match self {
             Self::Untracked(targets) => {
@@ -251,6 +252,8 @@ impl AbstractObjectInfo {
         }
     }
 
+    /// Remove the provided IDs from the target lists of all pointers in the memory object.
+    /// Also remove them from the pointer_targets list.
     pub fn remove_ids(&mut self, ids_to_remove: &BTreeSet<AbstractIdentifier>) {
         self.pointer_targets = self.pointer_targets.difference(ids_to_remove).cloned().collect();
         for value in self.memory.iter_values_mut() {

--- a/cwe_checker_rs/src/analysis/pointer_inference/object_list.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/object_list.rs
@@ -393,6 +393,11 @@ impl AbstractObjectList {
         }
     }
 
+    /// Remove the provided IDs as targets from all pointers in all objects.
+    /// Also forget whether the provided IDs point to objects in the object list.
+    ///
+    /// This may leave objects without known IDs pointing to them.
+    /// This function does *not* trim these objects from the object list.
     pub fn remove_ids(&mut self, ids_to_remove: &BTreeSet<AbstractIdentifier>) {
         for object in self.objects.iter_mut() {
             let object = Arc::make_mut(object);

--- a/cwe_checker_rs/src/analysis/pointer_inference/state.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/state.rs
@@ -538,6 +538,12 @@ impl State {
         self.ids_known_to_caller = self.ids_known_to_caller.difference(&ids_to_remove).cloned().collect();
     }
 
+    /// Add those objects from the caller_state to self, that are not known to self.
+    ///
+    /// Since self does not know these objects, we assume that the current function could not have accessed
+    /// them in any way during execution.
+    /// This means they are unchanged from the moment of the call until the return from the call,
+    /// thus we can simply copy their object-state from the moment of the call.
     pub fn readd_caller_objects(&mut self, caller_state: &State) {
         self.memory.append_unknown_objects(&caller_state.memory);
     }


### PR DESCRIPTION
This PR re-inserts return statements that were missing in the control flow graph. It also fixes some bugs found in the process.