### PR TITLE
replace let-bindings

### DIFF
--- a/cwe_checker_rs/src/ffi/analysis.rs
+++ b/cwe_checker_rs/src/ffi/analysis.rs
@@ -8,9 +8,10 @@ use super::failwith_on_panic;
 fn run_pointer_inference(program_jsonbuilder_val: ocaml::Value) -> (Vec<CweWarning>, Vec<String>) {
     let json_builder = unsafe { JsonBuilder::from_ocaml(&program_jsonbuilder_val) };
     let program_json = serde_json::Value::from(json_builder);
-    let project: Project =
+    let mut project: Project =
         serde_json::from_value(program_json).expect("Project deserialization failed");
 
+    project.replace_let_bindings();
     crate::analysis::pointer_inference::run(&project, false)
 }
 
@@ -26,9 +27,10 @@ caml!(rs_run_pointer_inference(program_jsonbuilder_val) {
 fn run_pointer_inference_and_print_debug(program_jsonbuilder_val: ocaml::Value) {
     let json_builder = unsafe { JsonBuilder::from_ocaml(&program_jsonbuilder_val) };
     let program_json = serde_json::Value::from(json_builder);
-    let project: Project =
+    let mut project: Project =
         serde_json::from_value(program_json).expect("Project deserialization failed");
 
+    project.replace_let_bindings();
     crate::analysis::pointer_inference::run(&project, true); // Note: This discard all CweWarnings and log messages.
 }
 


### PR DESCRIPTION
This PR adds a function to replace let-bindings in expressions with equivalent expressions without let-bindings on the Rust side, so that analyses do not have to cope with let-expressions if they do not want to.