### PR TITLE
Substitute trivial expressions

### DIFF
--- a/caller/src/main.rs
+++ b/caller/src/main.rs
@@ -41,6 +41,11 @@ struct CmdlineArgs {
     #[structopt(long)]
     module_versions: bool,
 
+    /// Output for debugging purposes.
+    /// The current behavior of this flag is unstable and subject to change.
+    #[structopt(long, hidden = true)]
+    debug: bool,
+
     /// Use BAP as backend (instead of Ghidra). Requires BAP and the cwe_checker-BAP-plugin to be installed.
     #[structopt(long, hidden = true)]
     bap: bool,
@@ -131,6 +136,18 @@ fn run_with_ghidra(args: CmdlineArgs) {
     }
 
     let project = get_project_from_ghidra(&Path::new(&args.binary.unwrap()));
+
+    // Print debug and then return.
+    // Right now there is only one debug printing function.
+    // When more debug printing modes exist, this behaviour will change!
+    if args.debug {
+        cwe_checker_rs::analysis::pointer_inference::run(
+            &project,
+            serde_json::from_value(config["Memory"].clone()).unwrap(),
+            true,
+        );
+        return;
+    }
 
     // Execute the modules and collect their logs and CWE-warnings.
     let mut all_logs = Vec::new();

--- a/cwe_checker_rs/src/pcode/expressions.rs
+++ b/cwe_checker_rs/src/pcode/expressions.rs
@@ -124,8 +124,13 @@ pub struct Expression {
 
 impl From<Expression> for IrExpression {
     /// Translates a P-Code expression into an expression of the internally used IR if possible.
-    /// Panics if translation is not possible,
-    /// e.g. for `LOAD`, `STORE` and and expressions that need the size of the output variable to be defined.
+    /// Panics if translation is not possible.
+    ///
+    /// Cases where translation is not possible:
+    /// - `LOAD` and `STORE`, since these are not expressions (they have side effects).
+    /// - Expressions which store the size of their output in the output variable (to which we do not have access here).
+    /// These include `SUBPIECE`, `INT_ZEXT`, `INT_SEXT`, `INT2FLOAT`, `FLOAT2FLOAT` and `TRUNC`.
+    /// Translation of these expressions is handled explicitly during translation of `Def`.
     fn from(expr: Expression) -> IrExpression {
         use ExpressionType::*;
         match expr.mnemonic {

--- a/cwe_checker_rs/src/pcode/expressions.rs
+++ b/cwe_checker_rs/src/pcode/expressions.rs
@@ -122,6 +122,35 @@ pub struct Expression {
     pub input2: Option<Variable>,
 }
 
+impl From<Expression> for IrExpression {
+    /// Translates a P-Code expression into an expression of the internally used IR if possible.
+    /// Panics if translation is not possible,
+    /// e.g. for `LOAD`, `STORE` and and expressions that need the size of the output variable to be defined.
+    fn from(expr: Expression) -> IrExpression {
+        use ExpressionType::*;
+        match expr.mnemonic {
+            COPY => expr.input0.unwrap().into(),
+            LOAD | STORE | SUBPIECE => panic!(),
+            PIECE | INT_EQUAL | INT_NOTEQUAL | INT_LESS | INT_SLESS | INT_LESSEQUAL
+            | INT_SLESSEQUAL | INT_ADD | INT_SUB | INT_CARRY | INT_SCARRY | INT_SBORROW
+            | INT_XOR | INT_AND | INT_OR | INT_LEFT | INT_RIGHT | INT_SRIGHT | INT_MULT
+            | INT_DIV | INT_REM | INT_SDIV | INT_SREM | BOOL_XOR | BOOL_AND | BOOL_OR
+            | FLOAT_EQUAL | FLOAT_NOTEQUAL | FLOAT_LESS | FLOAT_LESSEQUAL | FLOAT_ADD
+            | FLOAT_SUB | FLOAT_MULT | FLOAT_DIV => IrExpression::BinOp {
+                op: expr.mnemonic.into(),
+                lhs: Box::new(expr.input0.unwrap().into()),
+                rhs: Box::new(expr.input1.unwrap().into()),
+            },
+            INT_NEGATE | INT_2COMP | BOOL_NEGATE | FLOAT_NEG | FLOAT_ABS | FLOAT_SQRT
+            | FLOAT_CEIL | FLOAT_FLOOR | FLOAT_ROUND | FLOAT_NAN => IrExpression::UnOp {
+                op: expr.mnemonic.into(),
+                arg: Box::new(expr.input0.unwrap().into()),
+            },
+            INT_ZEXT | INT_SEXT | INT2FLOAT | FLOAT2FLOAT | TRUNC => panic!(),
+        }
+    }
+}
+
 #[allow(non_camel_case_types)]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum ExpressionType {
@@ -176,7 +205,7 @@ pub enum ExpressionType {
     INT_2COMP,
     BOOL_NEGATE,
 
-    FLOAT_NEGATE,
+    FLOAT_NEG,
     FLOAT_ABS,
     FLOAT_SQRT,
     FLOAT_CEIL,
@@ -253,7 +282,7 @@ impl From<ExpressionType> for IrUnOpType {
             INT_NEGATE => IrUnOpType::IntNegate,
             INT_2COMP => IrUnOpType::Int2Comp,
             BOOL_NEGATE => IrUnOpType::BoolNegate,
-            FLOAT_NEGATE => IrUnOpType::FloatNegate,
+            FLOAT_NEG => IrUnOpType::FloatNegate,
             FLOAT_ABS => IrUnOpType::FloatAbs,
             FLOAT_SQRT => IrUnOpType::FloatSqrt,
             FLOAT_CEIL => IrUnOpType::FloatCeil,

--- a/cwe_checker_rs/src/pcode/term.rs
+++ b/cwe_checker_rs/src/pcode/term.rs
@@ -412,7 +412,7 @@ impl From<Project> for IrProject {
             tid: project.program.tid,
             term: project.program.term.into(),
         };
-        IrProject {
+        let mut ir_project = IrProject {
             program,
             cpu_architecture: project.cpu_architecture,
             stack_pointer_register: project.stack_pointer_register.into(),
@@ -421,7 +421,9 @@ impl From<Project> for IrProject {
                 .into_iter()
                 .map(|cconv| cconv.into())
                 .collect(),
-        }
+        };
+        ir_project.normalize();
+        ir_project
     }
 }
 

--- a/cwe_checker_rs/src/pcode/term.rs
+++ b/cwe_checker_rs/src/pcode/term.rs
@@ -125,10 +125,6 @@ impl From<Def> for IrDef {
     fn from(def: Def) -> IrDef {
         use super::ExpressionType::*;
         match def.rhs.mnemonic {
-            COPY => IrDef::Assign {
-                var: def.lhs.unwrap().into(),
-                value: def.rhs.input0.unwrap().into(),
-            },
             LOAD => IrDef::Load {
                 var: def.lhs.unwrap().into(),
                 address: def.rhs.input1.unwrap().into(),
@@ -137,32 +133,11 @@ impl From<Def> for IrDef {
                 address: def.rhs.input1.unwrap().into(),
                 value: def.rhs.input2.unwrap().into(),
             },
-            PIECE | INT_EQUAL | INT_NOTEQUAL | INT_LESS | INT_SLESS | INT_LESSEQUAL
-            | INT_SLESSEQUAL | INT_ADD | INT_SUB | INT_CARRY | INT_SCARRY | INT_SBORROW
-            | INT_XOR | INT_AND | INT_OR | INT_LEFT | INT_RIGHT | INT_SRIGHT | INT_MULT
-            | INT_DIV | INT_REM | INT_SDIV | INT_SREM | BOOL_XOR | BOOL_AND | BOOL_OR
-            | FLOAT_EQUAL | FLOAT_NOTEQUAL | FLOAT_LESS | FLOAT_LESSEQUAL | FLOAT_ADD
-            | FLOAT_SUB | FLOAT_MULT | FLOAT_DIV => IrDef::Assign {
-                var: def.lhs.unwrap().into(),
-                value: IrExpression::BinOp {
-                    op: def.rhs.mnemonic.into(),
-                    lhs: Box::new(def.rhs.input0.unwrap().into()),
-                    rhs: Box::new(def.rhs.input1.unwrap().into()),
-                },
-            },
             SUBPIECE => IrDef::Assign {
                 var: def.lhs.clone().unwrap().into(),
                 value: IrExpression::Subpiece {
                     low_byte: def.rhs.input1.unwrap().parse_to_bytesize(),
                     size: def.lhs.unwrap().size,
-                    arg: Box::new(def.rhs.input0.unwrap().into()),
-                },
-            },
-            INT_NEGATE | INT_2COMP | BOOL_NEGATE | FLOAT_NEGATE | FLOAT_ABS | FLOAT_SQRT
-            | FLOAT_CEIL | FLOAT_FLOOR | FLOAT_ROUND | FLOAT_NAN => IrDef::Assign {
-                var: def.lhs.unwrap().into(),
-                value: IrExpression::UnOp {
-                    op: def.rhs.mnemonic.into(),
                     arg: Box::new(def.rhs.input0.unwrap().into()),
                 },
             },
@@ -174,6 +149,20 @@ impl From<Def> for IrDef {
                     arg: Box::new(def.rhs.input0.unwrap().into()),
                 },
             },
+            _ => {
+                let target_var = def.lhs.unwrap();
+                if target_var.address.is_some() {
+                    IrDef::Store {
+                        address: IrExpression::Const(target_var.parse_to_bitvector()),
+                        value: def.rhs.into(),
+                    }
+                } else {
+                    IrDef::Assign {
+                        var: target_var.into(),
+                        value: def.rhs.into(),
+                    }
+                }
+            }
         }
     }
 }
@@ -491,6 +480,32 @@ mod tests {
         }
       }
       "#,
+        )
+        .unwrap();
+        let _: IrDef = def.into();
+        let def: Def = serde_json::from_str(
+            r#"
+            {
+                "lhs": {
+                    "address": "004053e8",
+                    "size": 4,
+                    "is_virtual": false
+                },
+                "rhs": {
+                    "mnemonic": "INT_XOR",
+                    "input0": {
+                        "name": "$load_temp0",
+                        "size": 4,
+                        "is_virtual": true
+                    },
+                    "input1": {
+                        "name": "$U4780",
+                        "size": 4,
+                        "is_virtual": true
+                    }
+                }
+            }
+            "#,
         )
         .unwrap();
         let _: IrDef = def.into();

--- a/cwe_checker_rs/src/term/mod.rs
+++ b/cwe_checker_rs/src/term/mod.rs
@@ -362,12 +362,14 @@ impl From<Project> for IrProject {
             return_register: project.return_registers,
             callee_saved_register: project.callee_saved_registers,
         };
-        IrProject {
+        let mut ir_project = IrProject {
             program,
             cpu_architecture: project.cpu_architecture,
             stack_pointer_register: project.stack_pointer_register.into(),
             calling_conventions: vec![default_cconv],
-        }
+        };
+        ir_project.normalize();
+        ir_project
     }
 }
 

--- a/ghidra/p_code_extractor/PcodeExtractor.java
+++ b/ghidra/p_code_extractor/PcodeExtractor.java
@@ -875,8 +875,6 @@ public class PcodeExtractor extends GhidraScript {
         if (pcodeOp.getMnemonic().equals("STORE")) {
             return new Term<Def>(defTid, new Def(createExpression(pcodeOp), pcodeIndex));
             // cast copy instructions that have address outputs into store instructions
-        } else if (pcodeOp.getMnemonic().equals("COPY") && pcodeOp.getOutput().isAddress()) {
-            return new Term<Def>(defTid, new Def(new Expression("STORE", null, createVariable(pcodeOp.getOutput()), createVariable(pcodeOp.getInput(0))), pcodeIndex));
         }
         return new Term<Def>(defTid, new Def(createVariable(pcodeOp.getOutput()), createExpression(pcodeOp), pcodeIndex));
     }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -178,9 +178,8 @@ mod tests {
         mark_architecture_skipped(&mut tests, "mips64el"); // TODO: Check reason for failure!
         mark_architecture_skipped(&mut tests, "mips"); // TODO: Check reason for failure!
         mark_architecture_skipped(&mut tests, "mipsel"); // TODO: Check reason for failure!
-        mark_architecture_skipped(&mut tests, "ppc64"); // TODO: Check reason for failure!
-        mark_architecture_skipped(&mut tests, "ppc64le"); // TODO: Check reason for failure!
-        mark_architecture_skipped(&mut tests, "ppc"); // TODO: Check reason for failure!
+        mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
+        mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
         mark_skipped(&mut tests, "x86", "gcc"); // TODO: Check reason for failure!
         mark_compiler_skipped(&mut tests, "mingw32-gcc"); // TODO: Check reason for failure!
 
@@ -206,9 +205,8 @@ mod tests {
         mark_architecture_skipped(&mut tests, "mips64el"); // TODO: Check reason for failure!
         mark_architecture_skipped(&mut tests, "mips"); // TODO: Check reason for failure!
         mark_architecture_skipped(&mut tests, "mipsel"); // TODO: Check reason for failure!
-        mark_architecture_skipped(&mut tests, "ppc64"); // TODO: Check reason for failure!
-        mark_architecture_skipped(&mut tests, "ppc64le"); // TODO: Check reason for failure!
-        mark_architecture_skipped(&mut tests, "ppc"); // TODO: Check reason for failure!
+        mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
+        mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "x86"); // TODO: Check reason for failure!
         mark_compiler_skipped(&mut tests, "mingw32-gcc"); // TODO: Check reason for failure!
 
@@ -234,8 +232,8 @@ mod tests {
         mark_architecture_skipped(&mut tests, "mips64el"); // TODO: Check reason for failure!
         mark_skipped(&mut tests, "mips", "gcc"); // TODO: Check reason for failure!
         mark_skipped(&mut tests, "mipsel", "gcc"); // TODO: Check reason for failure!
-        mark_architecture_skipped(&mut tests, "ppc64"); // TODO: Check reason for failure!
-        mark_architecture_skipped(&mut tests, "ppc64le"); // TODO: Check reason for failure!
+        mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
+        mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
         mark_compiler_skipped(&mut tests, "mingw32-gcc"); // TODO: Check reason for failure!
 
         for test_case in tests {


### PR DESCRIPTION
This PR adds a normalization pass to the `Project` struct that substitutes trivially computable expressions like `a XOR a` with their result.

The PR should only be merged after the **Fix implicit stores** PR is merged.