### PR TITLE
implement check for CWE467 in Rust

### DIFF
--- a/cwe_checker_rs/src/checkers.rs
+++ b/cwe_checker_rs/src/checkers.rs
@@ -1,3 +1,4 @@
+pub mod cwe_467;
 pub mod cwe_560;
 pub mod cwe_676;
 pub mod cwe_782;

--- a/cwe_checker_rs/src/lib.rs
+++ b/cwe_checker_rs/src/lib.rs
@@ -51,6 +51,7 @@ impl std::fmt::Display for CweModule {
 /// Get a list of all known analysis modules.
 pub fn get_modules() -> Vec<&'static CweModule> {
     vec![
+        &crate::checkers::cwe_467::CWE_MODULE,
         &crate::checkers::cwe_560::CWE_MODULE,
         &crate::checkers::cwe_782::CWE_MODULE,
         &crate::checkers::cwe_676::CWE_MODULE,

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -240,6 +240,44 @@ mod tests {
 
     #[test]
     #[ignore]
+    fn cwe_467() {
+        let mut error_log = Vec::new();
+        let mut tests = linux_test_cases("cwe_467", "CWE467");
+
+        // Only one instance is found.
+        // Other instance cannot be found, since the constant is not defined in the basic block of the call instruction.
+        mark_skipped(&mut tests, "arm", "clang");
+        mark_skipped(&mut tests, "mips", "clang");
+        mark_skipped(&mut tests, "mipsel", "clang");
+
+        // Ghidra does not recognize all extern function calls in the disassembly step for MIPS.
+        // Needs own control flow graph analysis to be fixed.
+        mark_skipped(&mut tests, "mips64", "clang");
+        mark_skipped(&mut tests, "mips64el", "clang");
+        mark_skipped(&mut tests, "mips", "gcc");
+        mark_skipped(&mut tests, "mipsel", "gcc");
+
+        mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
+        mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
+
+        // This is a bug in the handling of sub-registers.
+        // Register `ECX` is read, but the analysis doesn't know that `ECX` is a sub-register of `RCX`.
+        mark_skipped(&mut tests, "x64", "clang");
+
+        for test_case in tests {
+            let num_expected_occurences = 2;
+            if let Err(error) = test_case.run_test("[CWE467]", num_expected_occurences) {
+                error_log.push((test_case.get_filepath(), error));
+            }
+        }
+        if !error_log.is_empty() {
+            print_errors(error_log);
+            panic!();
+        }
+    }
+
+    #[test]
+    #[ignore]
     fn cwe_560() {
         let mut error_log = Vec::new();
         let mut tests = linux_test_cases("cwe_560", "CWE560");


### PR DESCRIPTION
This PR reimplements the check for CWE 467 in Rust.