### PR TITLE
CWE 476

### DIFF
--- a/cwe_checker_rs/src/abstract_domain/bitvector.rs
+++ b/cwe_checker_rs/src/abstract_domain/bitvector.rs
@@ -203,17 +203,7 @@ impl RegisterDomain for BitvectorDomain {
                     BitvectorDomain::new_top(self.bytesize())
                 }
             },
-            _ => match op {
-                Piece => BitvectorDomain::new_top(self.bytesize() + rhs.bytesize()),
-                IntAdd | IntSub | IntMult | IntDiv | IntSDiv | IntRem | IntSRem | IntLeft
-                | IntRight | IntSRight | IntAnd | IntOr | IntXOr | FloatAdd | FloatSub
-                | FloatMult | FloatDiv => BitvectorDomain::new_top(self.bytesize()),
-                IntEqual | IntNotEqual | IntLess | IntLessEqual | IntSLess | IntSLessEqual
-                | IntCarry | IntSCarry | IntSBorrow | BoolAnd | BoolOr | BoolXOr | FloatEqual
-                | FloatNotEqual | FloatLess | FloatLessEqual => {
-                    BitvectorDomain::new_top(ByteSize::new(1))
-                }
-            },
+            _ => BitvectorDomain::new_top(self.bin_op_bytesize(op, rhs)),
         }
     }
 

--- a/cwe_checker_rs/src/abstract_domain/mem_region.rs
+++ b/cwe_checker_rs/src/abstract_domain/mem_region.rs
@@ -114,6 +114,12 @@ impl<T: AbstractDomain + HasByteSize + RegisterDomain + std::fmt::Debug> MemRegi
     pub fn add(&mut self, value: T, position: Bitvector) {
         assert_eq!(ByteSize::from(position.width()), self.address_bytesize);
         let position = Int::from(position).try_to_i64().unwrap();
+        self.insert_at_byte_index(value, position);
+    }
+
+    /// Insert a value into the memory region at the given position.
+    /// The position is the index (in bytes) in the memory region.
+    pub fn insert_at_byte_index(&mut self, value: T, position: i64) {
         let size_in_bytes = u64::from(value.bytesize()) as i64;
         assert!(size_in_bytes > 0);
 

--- a/cwe_checker_rs/src/abstract_domain/mod.rs
+++ b/cwe_checker_rs/src/abstract_domain/mod.rs
@@ -69,4 +69,19 @@ pub trait RegisterDomain: AbstractDomain + HasByteSize + HasTop {
 
     /// Perform a typecast to extend a bitvector or to cast between integer and floating point types.
     fn cast(&self, kind: CastOpType, width: ByteSize) -> Self;
+
+    /// Return the bytesize of the result of the given binary operation.
+    /// Has a generic implementation that should not be overwritten!
+    fn bin_op_bytesize(&self, op: BinOpType, rhs: &Self) -> ByteSize {
+        use BinOpType::*;
+        match op {
+            Piece => self.bytesize() + rhs.bytesize(),
+            IntAdd | IntSub | IntMult | IntDiv | IntSDiv | IntRem | IntSRem | IntLeft
+            | IntRight | IntSRight | IntAnd | IntOr | IntXOr | FloatAdd | FloatSub | FloatMult
+            | FloatDiv => self.bytesize(),
+            IntEqual | IntNotEqual | IntLess | IntLessEqual | IntSLess | IntSLessEqual
+            | IntCarry | IntSCarry | IntSBorrow | BoolAnd | BoolOr | BoolXOr | FloatEqual
+            | FloatNotEqual | FloatLess | FloatLessEqual => ByteSize::new(1),
+        }
+    }
 }

--- a/cwe_checker_rs/src/analysis/pointer_inference/context/tests.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/context/tests.rs
@@ -108,9 +108,8 @@ fn context_problem_implementation() {
     use Expression::*;
 
     let (project, config) = mock_project();
-    let (cwe_sender, _cwe_receiver) = crossbeam_channel::unbounded();
     let (log_sender, _log_receiver) = crossbeam_channel::unbounded();
-    let context = Context::new(&project, config, cwe_sender, log_sender);
+    let context = Context::new(&project, config, log_sender);
     let mut state = State::new(&register("RSP"), Tid::new("main"));
 
     let def = Term {
@@ -271,9 +270,8 @@ fn update_return() {
     use crate::analysis::pointer_inference::object::ObjectType;
     use crate::analysis::pointer_inference::Data;
     let (project, config) = mock_project();
-    let (cwe_sender, _cwe_receiver) = crossbeam_channel::unbounded();
     let (log_sender, _log_receiver) = crossbeam_channel::unbounded();
-    let context = Context::new(&project, config, cwe_sender, log_sender);
+    let context = Context::new(&project, config, log_sender);
     let state_before_return = State::new(&register("RSP"), Tid::new("callee"));
     let mut state_before_return = context
         .update_def(

--- a/cwe_checker_rs/src/analysis/pointer_inference/context/trait_impls.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/context/trait_impls.rs
@@ -29,7 +29,7 @@ impl<'a> crate::analysis::interprocedural_fixpoint::Context<'a> for Context<'a> 
                     def.tid.address
                 ),
             };
-            self.cwe_collector.send(warning).unwrap();
+            let _ = self.log_collector.send(LogThreadMsg::Cwe(warning));
         }
 
         match &def.term {

--- a/cwe_checker_rs/src/analysis/pointer_inference/mod.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/mod.rs
@@ -316,7 +316,7 @@ pub fn run(project: &Project, config: Config, print_debug: bool) -> PointerInfer
     computation
 }
 
-/// The function responsible for collecting logs and CWE warnings.
+/// This function is responsible for collecting logs and CWE warnings.
 /// For warnings with the same origin address only the last one is kept.
 /// This prevents duplicates but may suppress some log messages
 /// in the rare case that several different log messages with the same origin address are generated.

--- a/cwe_checker_rs/src/checkers.rs
+++ b/cwe_checker_rs/src/checkers.rs
@@ -2,6 +2,7 @@ pub mod cwe_190;
 pub mod cwe_332;
 pub mod cwe_426;
 pub mod cwe_467;
+pub mod cwe_476;
 pub mod cwe_560;
 pub mod cwe_676;
 pub mod cwe_782;

--- a/cwe_checker_rs/src/checkers/cwe_190.rs
+++ b/cwe_checker_rs/src/checkers/cwe_190.rs
@@ -100,9 +100,10 @@ fn generate_cwe_warning(callsite: &Tid, called_symbol: &ExternSymbol) -> CweWarn
 /// For each call to one of the symbols configured in config.json
 /// we check whether the block containing the call also contains a multiplication instruction.
 pub fn check_cwe(
-    project: &Project,
+    analysis_results: &AnalysisResults,
     cwe_params: &serde_json::Value,
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
+    let project = analysis_results.project;
     let config: Config = serde_json::from_value(cwe_params.clone()).unwrap();
     let mut cwe_warnings = Vec::new();
     let symbol_map = get_symbol_map(project, &config.symbols);

--- a/cwe_checker_rs/src/checkers/cwe_332.rs
+++ b/cwe_checker_rs/src/checkers/cwe_332.rs
@@ -20,7 +20,6 @@
 //!
 //! - It is not checked whether the seeding function gets called before the random number generator function.
 
-use crate::intermediate_representation::*;
 use crate::prelude::*;
 use crate::utils::log::{CweWarning, LogMessage};
 use crate::utils::symbol_utils::find_symbol;
@@ -56,9 +55,10 @@ fn generate_cwe_warning(secure_initializer_func: &str, rand_func: &str) -> CweWa
 
 /// Run the CWE check. See the module-level description for more information.
 pub fn check_cwe(
-    project: &Project,
+    analysis_results: &AnalysisResults,
     cwe_params: &serde_json::Value,
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
+    let project = analysis_results.project;
     let config: Config = serde_json::from_value(cwe_params.clone()).unwrap();
     let mut cwe_warnings = Vec::new();
 

--- a/cwe_checker_rs/src/checkers/cwe_426.rs
+++ b/cwe_checker_rs/src/checkers/cwe_426.rs
@@ -70,9 +70,10 @@ fn generate_cwe_warning(sub: &Term<Sub>) -> CweWarning {
 /// We check whether a function calls both `system(..)` and a privilege changing function.
 /// For each such function a CWE warning is generated.
 pub fn check_cwe(
-    project: &Project,
+    analysis_results: &AnalysisResults,
     cwe_params: &serde_json::Value,
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
+    let project = analysis_results.project;
     let config: Config = serde_json::from_value(cwe_params.clone()).unwrap();
     let mut cwe_warnings = Vec::new();
     let mut privilege_changing_symbols = HashMap::new();

--- a/cwe_checker_rs/src/checkers/cwe_467.rs
+++ b/cwe_checker_rs/src/checkers/cwe_467.rs
@@ -103,9 +103,10 @@ fn generate_cwe_warning(jmp: &Term<Jmp>, extern_symbol: &ExternSymbol) -> CweWar
 /// we check whether a parameter has value `sizeof(void*)`,
 /// which may indicate an instance of CWE 467.
 pub fn check_cwe(
-    project: &Project,
+    analysis_results: &AnalysisResults,
     cwe_params: &serde_json::Value,
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
+    let project = analysis_results.project;
     let config: Config = serde_json::from_value(cwe_params.clone()).unwrap();
     let mut cwe_warnings = Vec::new();
 

--- a/cwe_checker_rs/src/checkers/cwe_476.rs
+++ b/cwe_checker_rs/src/checkers/cwe_476.rs
@@ -1,0 +1,130 @@
+//! This module implements a check for CWE-476: NULL Pointer Dereference.
+//!
+//! Functions like `malloc()` may return NULL values instead of pointers to indicate
+//! failed calls. If one tries to access memory through this return value without
+//! checking it for being NULL first, this can crash the program.
+//!
+//! See <https://cwe.mitre.org/data/definitions/476.html> for a detailed description.
+//!
+//! ## How the check works
+//!
+//! Using dataflow analysis we search for an execution path where a memory access using the return value of
+//! a symbol happens before the return value is checked through a conditional jump instruction.
+//!
+//! ### Symbols configurable in config.json
+//!
+//! The symbols are the functions whose return values are assumed to be potential
+//! NULL pointers.
+//!
+//! ## False Positives
+//!
+//! - If a possible NULL pointer is temporarily saved in a memory location
+//! that the [Pointer Inference analysis](crate::analysis::pointer_inference) could not track,
+//! the analysis may miss a correct NULL pointer check and thus generate false positives.
+//! - The analysis is intraprocedural.
+//! If a parameter to a function is a potential NULL pointer,
+//! this gets flagged as a CWE hit even if the function may expect NULL pointers in its parameters.
+//! If a function returns a potential NULL pointer this gets flagged as a CWE hit,
+//! although the function may be supposed to return potential NULL pointers.
+//!
+//! ## False Negatives
+//!
+//! - We do not check whether an access to a potential NULL pointer happens regardless
+//! of a prior check.
+//! - We do not check whether the conditional jump instruction checks specifically
+//! for the return value being NULL or something else
+//! - For functions with more than one return value we do not distinguish between
+//! the return values.
+
+use crate::analysis::graph::{Edge, Node};
+use crate::analysis::interprocedural_fixpoint::Computation;
+use crate::analysis::interprocedural_fixpoint::Context as _;
+use crate::analysis::interprocedural_fixpoint::NodeValue;
+use crate::intermediate_representation::*;
+use crate::prelude::*;
+use crate::utils::log::{CweWarning, LogMessage};
+use crate::CweModule;
+use petgraph::visit::EdgeRef;
+use std::collections::HashMap;
+
+mod state;
+use state::*;
+
+mod taint;
+use taint::*;
+
+mod context;
+use context::*;
+
+pub static CWE_MODULE: CweModule = CweModule {
+    name: "CWE476",
+    version: "0.3",
+    run: check_cwe,
+};
+
+/// The configuration struct
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Config {
+    /// The names of symbols for which the analysis should check
+    /// whether the return values are checked for being a Null pointer by the analysed binary.
+    symbols: Vec<String>,
+}
+
+/// Run the CWE check.
+/// We check whether the return values of symbols configurable in the config file are being checked for Null pointers
+/// before any memory access (and thus potential Null pointer dereferences) through these values happen.
+pub fn check_cwe(
+    analysis_results: &AnalysisResults,
+    cwe_params: &serde_json::Value,
+) -> (Vec<LogMessage>, Vec<CweWarning>) {
+    let project = analysis_results.project;
+    let pointer_inference_results = analysis_results.pointer_inference.unwrap();
+
+    let (cwe_sender, cwe_receiver) = crossbeam_channel::unbounded();
+
+    let config: Config = serde_json::from_value(cwe_params.clone()).unwrap();
+    let symbol_map = crate::utils::symbol_utils::get_symbol_map(project, &config.symbols[..]);
+    let general_context = Context::new(project, &pointer_inference_results, cwe_sender);
+
+    for edge in general_context.get_graph().edge_references() {
+        if let Edge::ExternCallStub(jmp) = edge.weight() {
+            if let Jmp::Call { target, .. } = &jmp.term {
+                if let Some(symbol) = symbol_map.get(target) {
+                    let node = edge.target();
+                    let current_sub = match general_context.get_graph()[node] {
+                        Node::BlkStart(_blk, sub) => sub,
+                        _ => panic!(),
+                    };
+                    let mut context = general_context.clone();
+                    context.set_taint_source(jmp, current_sub);
+                    let pi_state_at_taint_source =
+                        match pointer_inference_results.get_node_value(node) {
+                            Some(NodeValue::Value(val)) => Some(val.clone()),
+                            _ => None,
+                        };
+                    let mut computation = Computation::new(context, None);
+                    computation.set_node_value(
+                        node,
+                        NodeValue::Value(State::new(
+                            symbol,
+                            &project.stack_pointer_register,
+                            pi_state_at_taint_source.as_ref(),
+                        )),
+                    );
+                    computation.compute_with_max_steps(100);
+                }
+            }
+        }
+    }
+
+    let mut cwe_warnings = HashMap::new();
+    for cwe in cwe_receiver.try_iter() {
+        match &cwe.addresses[..] {
+            [taint_source_address, ..] => cwe_warnings.insert(taint_source_address.clone(), cwe),
+            _ => panic!(),
+        };
+    }
+    let cwe_warnings = cwe_warnings.into_iter().map(|(_, cwe)| cwe).collect();
+
+    (Vec::new(), cwe_warnings)
+}

--- a/cwe_checker_rs/src/checkers/cwe_476/context.rs
+++ b/cwe_checker_rs/src/checkers/cwe_476/context.rs
@@ -1,0 +1,553 @@
+use super::State;
+use super::Taint;
+use super::CWE_MODULE;
+use crate::abstract_domain::AbstractDomain;
+use crate::analysis::graph::{Graph, Node};
+use crate::analysis::interprocedural_fixpoint::Context as _;
+use crate::analysis::interprocedural_fixpoint::NodeValue;
+use crate::analysis::pointer_inference::PointerInference as PointerInferenceComputation;
+use crate::analysis::pointer_inference::State as PointerInferenceState;
+use crate::intermediate_representation::*;
+use crate::prelude::*;
+use crate::utils::log::CweWarning;
+use petgraph::graph::NodeIndex;
+use petgraph::visit::IntoNodeReferences;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// The context object for the Null-Pointer-Dereference check.
+///
+/// There is always only one source of taint for the analysis.
+/// On creation of a `Context` object, the taint source is not set.
+/// Starting the fixpoint algorithm without
+/// [setting the taint source](Context::set_taint_source()) first will lead to a panic.
+/// By resetting the taint source one can reuse the context object for several fixpoint computations.
+#[derive(Clone)]
+pub struct Context<'a> {
+    /// A pointer to the corresponding project struct.
+    project: &'a Project,
+    /// A pointer to the results of the pointer inference analysis.
+    /// They are used to determine the targets of pointers to memory,
+    /// which in turn is used to keep track of taint on the stack or on the heap.
+    pub pointer_inference_results: &'a PointerInferenceComputation<'a>,
+    /// A map to get the node index of the `BlkStart` node containing a given [`Def`] as the first `Def` of the block.
+    /// The keys are of the form `(Def-TID, Current-Sub-TID)`
+    /// to distinguish the nodes for blocks contained in more than one function.
+    block_start_node_map: Arc<HashMap<(Tid, Tid), NodeIndex>>,
+    /// Maps the TID of an extern symbol to the extern symbol struct.
+    extern_symbol_map: Arc<HashMap<Tid, &'a ExternSymbol>>,
+    /// A map to get the node index of the `BlkEnd` node containing a given [`Jmp`].
+    /// The keys are of the form `(Jmp-TID, Current-Sub-TID)`
+    /// to distinguish the nodes for blocks contained in more than one function.
+    jmp_to_blk_end_node_map: Arc<HashMap<(Tid, Tid), NodeIndex>>,
+    /// The call whose return values are the sources for taint for the analysis.
+    taint_source: Option<&'a Term<Jmp>>,
+    /// The name of the function, whose return values are the taint sources.
+    taint_source_name: Option<String>,
+    /// The current subfunction.
+    ///Since the analysis is intraprocedural,
+    ///all nodes with state during the fixpoint algorithm should belong to this function.
+    current_sub: Option<&'a Term<Sub>>,
+    /// A channel where found CWE hits can be sent to.
+    cwe_collector: crossbeam_channel::Sender<CweWarning>,
+}
+
+impl<'a> Context<'a> {
+    /// Create a new context object.
+    ///
+    /// Note that one has to set the taint source separately before starting the analysis!
+    ///
+    /// If one wants to run the analysis for several sources,
+    /// one should clone or reuse an existing `Context` object instead of generating new ones,
+    /// since this function can be expensive!
+    pub fn new(
+        project: &'a Project,
+        pointer_inference_results: &'a PointerInferenceComputation<'a>,
+        cwe_collector: crossbeam_channel::Sender<CweWarning>,
+    ) -> Self {
+        let mut block_start_node_map = HashMap::new();
+        let mut jmp_to_blk_end_node_map = HashMap::new();
+        let graph = pointer_inference_results.get_graph();
+        for (node_id, node) in graph.node_references() {
+            match node {
+                Node::BlkStart(block, sub) => {
+                    if let Some(def) = block.term.defs.iter().next() {
+                        block_start_node_map.insert((def.tid.clone(), sub.tid.clone()), node_id);
+                    }
+                }
+                Node::BlkEnd(block, sub) => {
+                    for jmp in block.term.jmps.iter() {
+                        jmp_to_blk_end_node_map.insert((jmp.tid.clone(), sub.tid.clone()), node_id);
+                    }
+                }
+                _ => (),
+            }
+        }
+        let mut extern_symbol_map = HashMap::new();
+        for symbol in project.program.term.extern_symbols.iter() {
+            extern_symbol_map.insert(symbol.tid.clone(), symbol);
+        }
+        Context {
+            project,
+            pointer_inference_results,
+            block_start_node_map: Arc::new(block_start_node_map),
+            extern_symbol_map: Arc::new(extern_symbol_map),
+            jmp_to_blk_end_node_map: Arc::new(jmp_to_blk_end_node_map),
+            taint_source: None,
+            taint_source_name: None,
+            current_sub: None,
+            cwe_collector,
+        }
+    }
+
+    /// Set the taint source and the current function for the analysis.
+    pub fn set_taint_source(&mut self, taint_source: &'a Term<Jmp>, current_sub: &'a Term<Sub>) {
+        let taint_source_name = match &taint_source.term {
+            Jmp::Call { target, .. } => self
+                .project
+                .program
+                .term
+                .extern_symbols
+                .iter()
+                .find_map(|symb| {
+                    if symb.tid == *target {
+                        Some(symb.name.clone())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or("Unknown".to_string()),
+            _ => "Unknown".to_string(),
+        };
+        self.taint_source = Some(taint_source);
+        self.taint_source_name = Some(taint_source_name);
+        self.current_sub = Some(current_sub);
+    }
+
+    /// Get the current pointer inference state (if one can be found) for the given taint state.
+    fn get_current_pointer_inference_state(
+        &self,
+        state: &State,
+        tid: &Tid,
+    ) -> Option<PointerInferenceState> {
+        if let Some(pi_state) = state.get_pointer_inference_state() {
+            Some(pi_state.clone())
+        } else {
+            if let Some(node_id) = self
+                .block_start_node_map
+                .get(&(tid.clone(), self.current_sub.unwrap().tid.clone()))
+            {
+                match self.pointer_inference_results.get_node_value(*node_id) {
+                    Some(NodeValue::Value(val)) => Some(val.clone()),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        }
+    }
+
+    /// Update the pointer inference state contained in the given taint state
+    /// according to the effect of the given `Def` term.
+    fn update_pointer_inference_state(&self, state: &mut State, def: &Term<Def>) {
+        if let Some(pi_state) = self.get_current_pointer_inference_state(state, &def.tid) {
+            let pi_context = self.pointer_inference_results.get_context();
+            let new_pi_state = pi_context.update_def(&pi_state, def);
+            state.set_pointer_inference_state(new_pi_state);
+        }
+    }
+
+    /// Generate a CWE warning for the taint source of the context object.
+    fn generate_cwe_warning(&self, taint_access_location: &Tid) {
+        let taint_source = self.taint_source.unwrap();
+        let taint_source_name = self.taint_source_name.clone().unwrap();
+        let cwe_warning = CweWarning::new(CWE_MODULE.name, CWE_MODULE.version,
+            format!("(NULL Pointer Dereference) There is no check if the return value is NULL at {} ({}).",
+            taint_source.tid.address, taint_source_name))
+            .addresses(vec![taint_source.tid.address.clone(), taint_access_location.address.clone()])
+            .tids(vec![format!("{}", taint_source.tid), format!("{}", taint_access_location)])
+            .symbols(vec![taint_source_name]);
+        let _ = self.cwe_collector.send(cwe_warning);
+    }
+
+    /// Check whether the given function parameter contains taint
+    /// when evaluating it on the given state.
+    ///
+    /// The `node_id` is used to find the correct pointer inference state.
+    pub fn check_parameter_arg_for_taint(
+        &self,
+        parameter: &Arg,
+        state: &State,
+        node_id: NodeIndex,
+    ) -> Taint {
+        match parameter {
+            Arg::Register(var) => state.eval(&Expression::Var(var.clone())),
+            Arg::Stack { offset, size } => {
+                if let Some(NodeValue::Value(pi_state)) =
+                    self.pointer_inference_results.get_node_value(node_id)
+                {
+                    if let Ok(stack_address) = pi_state.eval(&Expression::BinOp {
+                        op: BinOpType::IntAdd,
+                        lhs: Box::new(Expression::Var(self.project.stack_pointer_register.clone())),
+                        rhs: Box::new(Expression::Const(
+                            Bitvector::from_i64(*offset)
+                                .into_truncate(apint::BitWidth::from(
+                                    self.project.stack_pointer_register.size,
+                                ))
+                                .unwrap(),
+                        )),
+                    }) {
+                        state.load_taint_from_memory(&stack_address, *size)
+                    } else {
+                        Taint::Top(*size)
+                    }
+                } else {
+                    Taint::Top(*size)
+                }
+            }
+        }
+    }
+
+    /// If a possible  parameter register of the call contains taint,
+    /// generate a CWE warning and return `None`.
+    /// Else remove all taint contained in non-callee-saved registers.
+    fn handle_generic_call(&self, state: &State, call_tid: &Tid) -> Option<State> {
+        // TODO: We do not yet check recursively for taint contained in objects pointed to by parameters.
+        if state.check_generic_function_params_for_taint(self.project) {
+            self.generate_cwe_warning(call_tid);
+            return None;
+        }
+        let mut new_state = state.clone();
+        if let Some(calling_conv) = self.project.get_standard_calling_convention() {
+            new_state.remove_non_callee_saved_taint(calling_conv);
+        }
+        return Some(new_state);
+    }
+}
+
+impl<'a> crate::analysis::interprocedural_fixpoint::Context<'a> for Context<'a> {
+    type Value = State;
+
+    /// Get the underlying graph of the fixpoint computation
+    fn get_graph(&self) -> &Graph<'a> {
+        self.pointer_inference_results.get_graph()
+    }
+
+    /// Merge two states
+    fn merge(&self, state1: &State, state2: &State) -> State {
+        state1.merge(state2)
+    }
+
+    /// Just returns a copy of the input state.
+    fn specialize_conditional(
+        &self,
+        state: &State,
+        _condition: &Expression,
+        _is_true: bool,
+    ) -> Option<State> {
+        Some(state.clone())
+    }
+
+    /// Generate a CWE warning if taint may be contained in the function parameters.
+    /// Always returns `None` so that the analysis stays intraprocedural.
+    fn update_call(&self, state: &State, call: &Term<Jmp>, _target: &Node) -> Option<Self::Value> {
+        if state.check_generic_function_params_for_taint(self.project) {
+            self.generate_cwe_warning(&call.tid);
+        }
+        // TODO: We do not yet check recursively for taint contained in objects pointed to by parameters.
+        None
+    }
+
+    /// If taint may be contained in the function parameters, generate a CWE warning and return None.
+    /// Else remove taint from non-callee-saved registers.
+    fn update_call_stub(&self, state: &State, call: &Term<Jmp>) -> Option<Self::Value> {
+        // TODO: We do not yet check recursively for taint contained in objects pointed to by parameters.
+        if state.is_empty() {
+            return None;
+        }
+        match &call.term {
+            Jmp::Call { target, .. } => {
+                if let Some(extern_symbol) = self.extern_symbol_map.get(target) {
+                    let blk_end_node_id = self
+                        .jmp_to_blk_end_node_map
+                        .get(&(call.tid.clone(), self.current_sub.unwrap().tid.clone()))
+                        .unwrap();
+                    for parameter in extern_symbol.parameters.iter() {
+                        if !self
+                            .check_parameter_arg_for_taint(parameter, state, *blk_end_node_id)
+                            .is_top()
+                        {
+                            self.generate_cwe_warning(&call.tid);
+                            return None;
+                        }
+                    }
+                    let mut new_state = state.clone();
+                    new_state.remove_non_callee_saved_taint(
+                        extern_symbol.get_calling_convention(self.project),
+                    );
+                    return Some(new_state);
+                } else {
+                    panic!("Extern symbol not found.");
+                }
+            }
+            Jmp::CallInd { .. } => self.handle_generic_call(state, &call.tid),
+            _ => panic!("Malformed control flow graph encountered."),
+        }
+    }
+
+    /// Update the taint state according to the effects of the given [`Def`].
+    /// If tainted memory is accessed through a load or store instruction
+    /// generate a CWE warning and return `None`.
+    fn update_def(&self, state: &State, def: &Term<Def>) -> Option<Self::Value> {
+        if state.is_empty() {
+            // Without taint there is nothing to propagate.
+            return None;
+        }
+        let mut new_state = state.clone();
+        match &def.term {
+            Def::Assign { var, value } => {
+                new_state.set_register_taint(var, state.eval(value));
+            }
+            Def::Load { var, address } => {
+                if state.eval(address).is_tainted() {
+                    self.generate_cwe_warning(&def.tid);
+                    return None;
+                } else {
+                    if let Some(pi_state) =
+                        self.get_current_pointer_inference_state(state, &def.tid)
+                    {
+                        if let Ok(address_data) = pi_state.eval(address) {
+                            let taint = state.load_taint_from_memory(&address_data, var.size);
+                            new_state.set_register_taint(var, taint);
+                        }
+                    } else {
+                        new_state.set_register_taint(var, Taint::Top(var.size));
+                    }
+                }
+            }
+            Def::Store { address, value } => {
+                if state.eval(address).is_tainted() {
+                    self.generate_cwe_warning(&def.tid);
+                    return None;
+                } else {
+                    if let Some(pi_state) =
+                        self.get_current_pointer_inference_state(state, &def.tid)
+                    {
+                        if let Ok(address_data) = pi_state.eval(address) {
+                            let taint = state.eval(value);
+                            new_state.save_taint_to_memory(&address_data, taint);
+                        }
+                    } else {
+                        // We lost all knowledge about memory pointers.
+                        // We delete all memory taint to reduce false positives.
+                        new_state.remove_all_memory_taints();
+                    }
+                }
+            }
+        }
+        self.update_pointer_inference_state(&mut new_state, def);
+        Some(new_state)
+    }
+
+    /// Update the state according to a jump instruction.
+    /// Checks whether the jump or the untaken conditional jump is a `CBranch` instruction
+    /// which checks a tainted value.
+    /// If yes, we assume that the taint source was correctly checked for being a Null pointer and return `None`.
+    /// If no we only remove the `pointer_inference_state` from the state.
+    fn update_jump(
+        &self,
+        state: &State,
+        jump: &Term<Jmp>,
+        untaken_conditional: Option<&Term<Jmp>>,
+        _target: &Term<Blk>,
+    ) -> Option<Self::Value> {
+        if state.is_empty() {
+            // Without taint there is nothing to propagate.
+            return None;
+        }
+        if let Jmp::CBranch { condition, .. } = &jump.term {
+            if state.eval(condition).is_tainted() {
+                return None;
+            }
+        }
+        if let Some(untaken_jump) = untaken_conditional {
+            if let Jmp::CBranch { condition, .. } = &untaken_jump.term {
+                if state.eval(condition).is_tainted() {
+                    return None;
+                }
+            }
+        }
+        let mut new_state = state.clone();
+        new_state.set_pointer_inference_state(None);
+        Some(new_state)
+    }
+
+    /// If `state_before_return` is set and contains taint,
+    /// generate a CWE warning (since the function may return a Null pointer in this case).
+    /// If `state_before_call` is set, handle it like a generic extern function call
+    /// (see [`update_call_stub`](Context::update_call_stub()) for more).
+    fn update_return(
+        &self,
+        state_before_return: Option<&State>,
+        state_before_call: Option<&State>,
+        call_term: &Term<Jmp>,
+        return_term: &Term<Jmp>,
+    ) -> Option<State> {
+        if let Some(state) = state_before_return {
+            // If taint is returned, generate a CWE warning
+            if !state.is_empty() {
+                self.generate_cwe_warning(&return_term.tid)
+            }
+            // Do not return early in case `state_before_call` is also set (possible for recursive functions).
+        }
+        if let Some(state) = state_before_call {
+            self.handle_generic_call(state, &call_term.tid)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl<'a> Context<'a> {
+        pub fn mock(
+            project: &'a Project,
+            pi_results: &'a PointerInferenceComputation<'a>,
+        ) -> Context<'a> {
+            let (cwe_sender, _) = crossbeam_channel::unbounded();
+            let mut context = Context::new(project, pi_results, cwe_sender);
+            let taint_source = Box::new(Term {
+                tid: Tid::new("taint_source"),
+                term: Jmp::Call {
+                    target: Tid::new("malloc"),
+                    return_: None,
+                },
+            });
+            let taint_source = Box::leak(taint_source);
+            let current_sub = Box::new(Sub::mock("current_sub"));
+            let current_sub = Box::leak(current_sub);
+            context.set_taint_source(taint_source, current_sub);
+            context
+        }
+    }
+
+    #[test]
+    fn check_parameter_arg_for_taint() {
+        let project = Project::mock_empty();
+        let pi_results = PointerInferenceComputation::mock(&project);
+        let context = Context::mock(&project, &pi_results);
+        let (state, _pi_state) = State::mock_with_pi_state();
+
+        let arg = Arg::Register(Variable::mock("RAX", 8u64));
+        let param_taint = context.check_parameter_arg_for_taint(&arg, &state, NodeIndex::new(0));
+        assert!(param_taint.is_tainted());
+
+        let arg = Arg::Register(Variable::mock("RBX", 8u64));
+        let param_taint = context.check_parameter_arg_for_taint(&arg, &state, NodeIndex::new(0));
+        assert!(!param_taint.is_tainted());
+    }
+
+    #[test]
+    fn handle_generic_call() {
+        let project = Project::mock_empty();
+        let pi_results = PointerInferenceComputation::mock(&project);
+        let context = Context::mock(&project, &pi_results);
+        let mut state = State::mock();
+
+        assert!(context
+            .handle_generic_call(&state, &Tid::new("call_tid"))
+            .is_some());
+
+        state.set_register_taint(
+            &Variable::mock("RDX", 8u64),
+            Taint::Tainted(ByteSize::new(8)),
+        );
+        assert!(context
+            .handle_generic_call(&state, &Tid::new("call_tid"))
+            .is_none());
+    }
+
+    #[test]
+    fn update_def() {
+        let project = Project::mock_empty();
+        let pi_results = PointerInferenceComputation::mock(&project);
+        let context = Context::mock(&project, &pi_results);
+        let (mut state, pi_state) = State::mock_with_pi_state();
+        state.set_pointer_inference_state(Some(pi_state));
+
+        let assign_def = Term {
+            tid: Tid::new("def"),
+            term: Def::Assign {
+                var: Variable::mock("RCX", 8u64),
+                value: Expression::Var(Variable::mock("RAX", 8u64)),
+            },
+        };
+        let result = context.update_def(&state, &assign_def).unwrap();
+        assert!(result
+            .eval(&Expression::Var(Variable::mock("RCX", 8u64)))
+            .is_tainted());
+        assert!(result
+            .eval(&Expression::Var(Variable::mock("RSP", 8u64)))
+            .is_top());
+
+        let load_def = Term {
+            tid: Tid::new("def"),
+            term: Def::Load {
+                var: Variable::mock("RCX", 8u64),
+                address: Expression::Var(Variable::mock("RSP", 8u64)),
+            },
+        };
+        let result = context.update_def(&state, &load_def).unwrap();
+        assert!(result
+            .eval(&Expression::Var(Variable::mock("RCX", 8u64)))
+            .is_tainted());
+        assert!(result
+            .eval(&Expression::Var(Variable::mock("RSP", 8u64)))
+            .is_top());
+
+        let store_def = Term {
+            tid: Tid::new("def"),
+            term: Def::Store {
+                value: Expression::Var(Variable::mock("RCX", 8u64)),
+                address: Expression::Var(Variable::mock("RSP", 8u64)),
+            },
+        };
+        let result = context.update_def(&state, &store_def).unwrap();
+        let result = context.update_def(&result, &load_def).unwrap();
+        assert!(result
+            .eval(&Expression::Var(Variable::mock("RCX", 8u64)))
+            .is_top());
+    }
+
+    #[test]
+    fn update_jump() {
+        let project = Project::mock_empty();
+        let pi_results = PointerInferenceComputation::mock(&project);
+        let context = Context::mock(&project, &pi_results);
+        let (state, _pi_state) = State::mock_with_pi_state();
+
+        let jump = Term {
+            tid: Tid::new("jmp"),
+            term: Jmp::CBranch {
+                target: Tid::new("target"),
+                condition: Expression::Var(Variable::mock("RAX", 8u64)),
+            },
+        };
+        assert!(context
+            .update_jump(&state, &jump, None, &Blk::mock())
+            .is_none());
+        let jump = Term {
+            tid: Tid::new("jmp"),
+            term: Jmp::CBranch {
+                target: Tid::new("target"),
+                condition: Expression::Var(Variable::mock("RBX", 8u64)),
+            },
+        };
+        assert!(context
+            .update_jump(&state, &jump, None, &Blk::mock())
+            .is_some());
+    }
+}

--- a/cwe_checker_rs/src/checkers/cwe_476/state.rs
+++ b/cwe_checker_rs/src/checkers/cwe_476/state.rs
@@ -1,0 +1,423 @@
+use crate::abstract_domain::{
+    AbstractDomain, AbstractIdentifier, BitvectorDomain, HasByteSize, MemRegion, RegisterDomain,
+};
+use crate::analysis::pointer_inference::Data;
+use crate::analysis::pointer_inference::State as PointerInferenceState;
+use crate::intermediate_representation::*;
+use crate::prelude::*;
+use std::collections::HashMap;
+
+use super::Taint;
+
+/// The state object of the taint analysis representing all known tainted memory and register values.
+#[derive(Serialize, Deserialize, Debug, Eq, Clone)]
+pub struct State {
+    /// The set of currently tainted registers.
+    register_taint: HashMap<Variable, Taint>,
+    /// The Taint contained in memory objects
+    memory_taint: HashMap<AbstractIdentifier, MemRegion<Taint>>,
+    /// The state of the pointer inference analysis.
+    /// Used only for preventing unneccessary recomputation during handling of `Def`s in a basic block.
+    /// It is set when handling `Def`s (except for the first `Def` in a block)
+    /// provided that a corresponding pointer inference analysis state exists.
+    /// Otherwise the field is ignored (including in the [merge](State::merge)-function) and usually set to `None`.
+    #[serde(skip_serializing)]
+    pointer_inference_state: Option<PointerInferenceState>,
+}
+
+impl PartialEq for State {
+    /// Two states are equal if the same values are tainted in both states.
+    ///
+    /// The equality operator ignores the `pointer_inference_state` field,
+    /// since it only denotes an intermediate value.
+    fn eq(&self, other: &Self) -> bool {
+        self.register_taint == other.register_taint && self.memory_taint == other.memory_taint
+    }
+}
+
+impl AbstractDomain for State {
+    /// Merge two states.
+    /// Any value tainted in at least one input state is also tainted in the merged state.
+    ///
+    /// The used algorithm for merging the taints contained in memory regions is unsound
+    /// when merging taints that intersect only partially.
+    /// However, this should not have an effect in practice,
+    /// since these values are usually unsound and unused by the program anyway.
+    fn merge(&self, other: &Self) -> Self {
+        let mut register_taint = self.register_taint.clone();
+        for (var, other_taint) in other.register_taint.iter() {
+            if let Some(taint) = self.register_taint.get(var) {
+                register_taint.insert(var.clone(), taint.merge(other_taint));
+            } else {
+                register_taint.insert(var.clone(), other_taint.clone());
+            }
+        }
+
+        let mut memory_taint = self.memory_taint.clone();
+        for (tid, other_mem_region) in other.memory_taint.iter() {
+            if let Some(mem_region) = memory_taint.get_mut(tid) {
+                for (index, taint) in other_mem_region.iter() {
+                    mem_region.insert_at_byte_index(*taint, *index);
+                    // Unsound in theory for partially intersecting taints. Should not matter in practice.
+                }
+            } else {
+                memory_taint.insert(tid.clone(), other_mem_region.clone());
+            }
+        }
+
+        State {
+            register_taint,
+            memory_taint,
+            pointer_inference_state: None, // At nodes this intermediate value can be safely forgotten.
+        }
+    }
+
+    /// The state has no explicit Top element.
+    fn is_top(&self) -> bool {
+        false
+    }
+}
+
+impl State {
+    /// Get a new state in which only the return values of the given extern symbol are tainted.
+    pub fn new(
+        taint_source: &ExternSymbol,
+        stack_pointer_register: &Variable,
+        pi_state: Option<&PointerInferenceState>,
+    ) -> State {
+        let mut state = State {
+            register_taint: HashMap::new(),
+            memory_taint: HashMap::new(),
+            pointer_inference_state: None,
+        };
+        for return_arg in taint_source.return_values.iter() {
+            match return_arg {
+                Arg::Register(var) => {
+                    state
+                        .register_taint
+                        .insert(var.clone(), Taint::Tainted(var.size));
+                }
+                Arg::Stack { offset, size } => {
+                    if let Some(pi_state) = pi_state {
+                        let address_exp = Expression::BinOp {
+                            op: BinOpType::IntAdd,
+                            lhs: Box::new(Expression::Var(stack_pointer_register.clone())),
+                            rhs: Box::new(Expression::Const(
+                                Bitvector::from_i64(*offset)
+                                    .into_truncate(apint::BitWidth::from(
+                                        stack_pointer_register.size,
+                                    ))
+                                    .unwrap(),
+                            )),
+                        };
+                        if let Ok(address) = pi_state.eval(&address_exp) {
+                            state.save_taint_to_memory(&address, Taint::Tainted(*size));
+                        }
+                    }
+                }
+            }
+        }
+        state
+    }
+
+    /// Evaluate whether the result of the given expression is tainted in the current state.
+    pub fn eval(&self, expression: &Expression) -> Taint {
+        match expression {
+            Expression::Const(_) => Taint::Top(expression.bytesize()),
+            Expression::Var(var) => {
+                if self.register_taint.get(var).is_some() {
+                    Taint::Tainted(var.size)
+                } else {
+                    Taint::Top(var.size)
+                }
+            }
+            Expression::BinOp { op, lhs, rhs } => {
+                let lhs_taint = self.eval(lhs);
+                let rhs_taint = self.eval(rhs);
+                lhs_taint.bin_op(*op, &rhs_taint)
+            }
+            Expression::UnOp { op, arg } => self.eval(arg).un_op(*op),
+            Expression::Unknown { size, .. } => Taint::Top(*size),
+            Expression::Cast { op, size, arg } => self.eval(arg).cast(*op, *size),
+            Expression::Subpiece {
+                low_byte,
+                size,
+                arg,
+            } => self.eval(arg).subpiece(*low_byte, *size),
+        }
+    }
+
+    /// Get the current pointer inference state if it is contained as an intermediate value in the state.
+    pub fn get_pointer_inference_state(&self) -> Option<&PointerInferenceState> {
+        self.pointer_inference_state.as_ref()
+    }
+
+    /// Set the current pointer inference state for `self`.
+    pub fn set_pointer_inference_state(&mut self, pi_state: Option<PointerInferenceState>) {
+        self.pointer_inference_state = pi_state;
+    }
+
+    /// Return whether the value at the given address (with the given size) is tainted.
+    pub fn load_taint_from_memory(&self, address: &Data, size: ByteSize) -> Taint {
+        let mut taint = Taint::Top(size);
+        if let Data::Pointer(pointer) = address {
+            for (mem_id, offset) in pointer.targets().iter() {
+                match (self.memory_taint.get(mem_id), offset) {
+                    (Some(mem_region), BitvectorDomain::Value(position)) => {
+                        taint = taint.merge(&mem_region.get(position.clone(), size));
+                    }
+                    _ => (),
+                }
+            }
+        }
+        taint
+    }
+
+    /// Mark the value at the given address with the given taint.
+    ///
+    /// If the address may point to more than one object,
+    /// we merge the taint object with the object at the targets,
+    /// possibly tainting all possible targets.
+    pub fn save_taint_to_memory(&mut self, address: &Data, taint: Taint) {
+        if let Data::Pointer(pointer) = address {
+            if pointer.targets().len() == 1 {
+                for (mem_id, offset) in pointer.targets().iter() {
+                    if let BitvectorDomain::Value(position) = offset {
+                        if let Some(mem_region) = self.memory_taint.get_mut(mem_id) {
+                            mem_region.add(taint.clone(), position.clone());
+                        } else {
+                            let mut mem_region = MemRegion::new(address.bytesize());
+                            mem_region.add(taint.clone(), position.clone());
+                            self.memory_taint.insert(mem_id.clone(), mem_region);
+                        }
+                    }
+                }
+            } else {
+                for (mem_id, offset) in pointer.targets().iter() {
+                    if let BitvectorDomain::Value(position) = offset {
+                        if let Some(mem_region) = self.memory_taint.get_mut(mem_id) {
+                            let old_taint = mem_region.get(position.clone(), taint.bytesize());
+                            mem_region.add(old_taint.merge(&taint), position.clone());
+                        } else {
+                            let mut mem_region = MemRegion::new(address.bytesize());
+                            mem_region.add(taint.clone(), position.clone());
+                            self.memory_taint.insert(mem_id.clone(), mem_region);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Remove all knowledge about taints contained in memory objects.
+    pub fn remove_all_memory_taints(&mut self) {
+        self.memory_taint = HashMap::new();
+    }
+
+    /// Set the taint of a register.
+    pub fn set_register_taint(&mut self, register: &Variable, taint: Taint) {
+        if taint.is_top() {
+            self.register_taint.remove(register);
+        } else {
+            self.register_taint.insert(register.clone(), taint);
+        }
+    }
+
+    /// Check whether a generic function call may contain tainted values in its parameters.
+    /// Since we don't know the actual calling convention of the call,
+    /// we approximate the parameters with all parameter registers of the standard calling convention of the project.
+    pub fn check_generic_function_params_for_taint(&self, project: &Project) -> bool {
+        if let Some(calling_conv) = project.get_standard_calling_convention() {
+            for (register, taint) in &self.register_taint {
+                if calling_conv
+                    .parameter_register
+                    .iter()
+                    .any(|param| *param == register.name)
+                {
+                    if !taint.is_top() {
+                        return true;
+                    }
+                }
+            }
+            false
+        } else {
+            // No standard calling convention found. Assume all registers may be parameters.
+            self.register_taint.values().any(|taint| !taint.is_top())
+        }
+    }
+
+    /// Remove the taint from all registers not contained in the callee-saved register list of the given calling convention.
+    pub fn remove_non_callee_saved_taint(&mut self, calling_conv: &CallingConvention) {
+        self.register_taint = self
+            .register_taint
+            .iter()
+            .filter_map(|(register, taint)| {
+                if calling_conv
+                    .callee_saved_register
+                    .iter()
+                    .any(|callee_saved_reg| register.name == *callee_saved_reg)
+                {
+                    Some((register.clone(), taint.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+    }
+
+    /// Check whether `self` contains any taint at all.
+    pub fn is_empty(&self) -> bool {
+        self.memory_taint.is_empty() && self.register_taint.is_empty()
+    }
+}
+
+impl State {
+    /// Get a more compact json-representation of the state.
+    /// Intended for pretty printing, not useable for serialization/deserialization.
+    #[allow(dead_code)]
+    pub fn to_json_compact(&self) -> serde_json::Value {
+        use serde_json::*;
+        use std::iter::FromIterator;
+        let register: Vec<(String, Value)> = self
+            .register_taint
+            .iter()
+            .map(|(var, data)| (var.name.clone(), json!(format!("{}", data))))
+            .collect();
+        let mut memory = Vec::new();
+        for (tid, mem_region) in self.memory_taint.iter() {
+            let mut elements = Vec::new();
+            for (offset, elem) in mem_region.iter() {
+                elements.push((offset.to_string(), json!(elem.to_string())));
+            }
+            memory.push((format!("{}", tid), Value::Object(Map::from_iter(elements))));
+        }
+        let mut state_map = Vec::new();
+        state_map.push((
+            "register".to_string(),
+            Value::Object(Map::from_iter(register)),
+        ));
+        state_map.push(("memory".to_string(), Value::Object(Map::from_iter(memory))));
+
+        Value::Object(Map::from_iter(state_map))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abstract_domain::*;
+
+    impl State {
+        pub fn mock() -> State {
+            State {
+                register_taint: HashMap::new(),
+                memory_taint: HashMap::new(),
+                pointer_inference_state: None,
+            }
+        }
+
+        pub fn mock_with_pi_state() -> (State, PointerInferenceState) {
+            let arg1 = Arg::Register(register("RAX"));
+            let arg2 = Arg::Stack {
+                offset: 0,
+                size: ByteSize::new(8),
+            };
+            let pi_state = PointerInferenceState::new(&register("RSP"), Tid::new("func"));
+            let symbol = ExternSymbol {
+                tid: Tid::new("extern_symbol".to_string()),
+                addresses: vec![],
+                name: "extern_symbol".into(),
+                calling_convention: None,
+                parameters: Vec::new(),
+                return_values: vec![arg1, arg2],
+                no_return: false,
+            };
+            let state = State::new(&symbol, &register("RSP"), Some(&pi_state));
+            (state, pi_state)
+        }
+    }
+
+    fn register(name: &str) -> Variable {
+        Variable {
+            name: name.into(),
+            size: ByteSize::new(8),
+            is_temp: false,
+        }
+    }
+
+    fn bv(value: i64) -> BitvectorDomain {
+        BitvectorDomain::Value(Bitvector::from_i64(value))
+    }
+
+    fn new_id(name: &str) -> AbstractIdentifier {
+        AbstractIdentifier::new(
+            Tid::new("time0"),
+            AbstractLocation::Register(name.into(), ByteSize::new(8)),
+        )
+    }
+
+    fn new_pointer_domain(location: &str, offset: i64) -> PointerDomain<BitvectorDomain> {
+        let id = new_id(location);
+        PointerDomain::new(id, bv(offset))
+    }
+
+    #[test]
+    fn merge_state() {
+        let taint = Taint::Tainted(ByteSize::new(8));
+        let top = Taint::Top(ByteSize::new(8));
+
+        let mut state = State::mock();
+        state.set_register_taint(&register("RAX"), taint.clone());
+
+        let mut other_state = State::mock();
+        let address = Data::Pointer(new_pointer_domain("mem", 10));
+        other_state.save_taint_to_memory(&address, taint);
+
+        let merged_state = state.merge(&other_state);
+        assert_eq!(
+            merged_state.register_taint.get(&register("RAX")),
+            Some(&taint)
+        );
+        assert_eq!(merged_state.register_taint.get(&register("RBX")), None);
+        assert_eq!(
+            merged_state.load_taint_from_memory(&address, ByteSize::new(8)),
+            taint.clone()
+        );
+        let other_address = Data::Pointer(new_pointer_domain("mem", 18));
+        assert_eq!(
+            merged_state.load_taint_from_memory(&other_address, ByteSize::new(8)),
+            top.clone()
+        );
+    }
+
+    #[test]
+    fn new_state() {
+        let (state, pi_state) = State::mock_with_pi_state();
+        let taint = Taint::Tainted(ByteSize::new(8));
+        assert_eq!(state.register_taint.get(&register("RAX")), Some(&taint));
+        assert_eq!(state.register_taint.get(&register("RSP")), None);
+        let address = Expression::Var(register("RSP"));
+        assert_eq!(
+            state.load_taint_from_memory(&pi_state.eval(&address).unwrap(), ByteSize::new(8)),
+            taint
+        );
+    }
+
+    #[test]
+    fn eval_expression() {
+        let (state, _pi_state) = State::mock_with_pi_state();
+
+        let expr = Expression::BinOp {
+            lhs: Box::new(Expression::Var(register("RAX"))),
+            op: BinOpType::IntAdd,
+            rhs: Box::new(Expression::Var(register("RBX"))),
+        };
+        assert!(state.eval(&expr).is_tainted());
+
+        let expr = Expression::UnOp {
+            op: UnOpType::Int2Comp,
+            arg: Box::new(Expression::Var(register("RSP"))),
+        };
+        assert!(state.eval(&expr).is_top());
+    }
+}

--- a/cwe_checker_rs/src/checkers/cwe_476/taint.rs
+++ b/cwe_checker_rs/src/checkers/cwe_476/taint.rs
@@ -79,7 +79,7 @@ impl RegisterDomain for Taint {
 
     /// The result of a unary operation is tainted if the input was tainted.
     fn un_op(&self, _op: UnOpType) -> Self {
-        self.clone()
+        *self
     }
 
     /// A subpiece of a tainted value is again tainted.

--- a/cwe_checker_rs/src/checkers/cwe_476/taint.rs
+++ b/cwe_checker_rs/src/checkers/cwe_476/taint.rs
@@ -1,0 +1,135 @@
+use crate::abstract_domain::{AbstractDomain, HasByteSize, HasTop, RegisterDomain};
+use crate::intermediate_representation::*;
+use crate::prelude::*;
+use std::fmt::Display;
+
+/// An abstract domain representing a value that is either tainted or not.
+///
+/// Note that the [merge](Taint::merge)-function does not respect the partial order
+/// that is implied by the naming scheme of the variants!
+/// In fact the whole analysis does not enforce any partial order for this domain.
+/// This means that in theory the fixpoint computation may not actually converge to a fixpoint,
+/// but in practice the analysis can make more precise decisions
+/// whether a value should be tainted or not.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+pub enum Taint {
+    /// A tainted value of a particular bytesize.
+    Tainted(ByteSize),
+    /// An untainted value of a particular bytesize
+    Top(ByteSize),
+}
+
+impl Display for Taint {
+    /// Print the value of a `Taint` object.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tainted(size) => write!(f, "Tainted:{}", size),
+            Self::Top(size) => write!(f, "Top:{}", size),
+        }
+    }
+}
+
+impl AbstractDomain for Taint {
+    /// The result of merging two `Taint` values is tainted if at least one input was tainted.
+    fn merge(&self, other: &Self) -> Self {
+        use Taint::*;
+        match (self, other) {
+            (Tainted(size), _) | (_, Tainted(size)) => Tainted(*size),
+            _ => Top(self.bytesize()),
+        }
+    }
+
+    /// Checks whether the value is an untainted `Top`-value.
+    fn is_top(&self) -> bool {
+        matches!(self, Taint::Top(_))
+    }
+}
+
+impl HasByteSize for Taint {
+    /// The size in bytes of the `Taint` value.
+    fn bytesize(&self) -> ByteSize {
+        match self {
+            Self::Tainted(size) | Self::Top(size) => *size,
+        }
+    }
+}
+
+impl HasTop for Taint {
+    /// Get a new `Top`-value with the same bytesize as `self`.
+    fn top(&self) -> Self {
+        Self::Top(self.bytesize())
+    }
+}
+
+impl RegisterDomain for Taint {
+    /// Get a new `Top`-value with the given bytesize.
+    fn new_top(bytesize: ByteSize) -> Self {
+        Self::Top(bytesize)
+    }
+
+    /// The result of a binary operation is tainted if at least one input value was tainted.
+    fn bin_op(&self, op: BinOpType, rhs: &Self) -> Self {
+        match (self, rhs) {
+            (Self::Tainted(_), _) | (_, Self::Tainted(_)) => {
+                Self::Tainted(self.bin_op_bytesize(op, rhs))
+            }
+            _ => Self::Top(self.bin_op_bytesize(op, rhs)),
+        }
+    }
+
+    /// The result of a unary operation is tainted if the input was tainted.
+    fn un_op(&self, _op: UnOpType) -> Self {
+        self.clone()
+    }
+
+    /// A subpiece of a tainted value is again tainted.
+    fn subpiece(&self, _low_byte: ByteSize, size: ByteSize) -> Self {
+        if let Self::Tainted(_) = self {
+            Self::Tainted(size)
+        } else {
+            Self::Top(size)
+        }
+    }
+
+    /// The result of a cast operation is tainted if the input was tainted.
+    fn cast(&self, _kind: CastOpType, width: ByteSize) -> Self {
+        if let Self::Tainted(_) = self {
+            Self::Tainted(width)
+        } else {
+            Self::Top(width)
+        }
+    }
+}
+
+impl Taint {
+    /// Checks whether the given value is in fact tainted.
+    pub fn is_tainted(&self) -> bool {
+        matches!(self, Taint::Tainted(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abstract_domain() {
+        let taint = Taint::Tainted(ByteSize::new(4));
+        let top = Taint::Top(ByteSize::new(4));
+        assert_eq!(taint.merge(&top), taint);
+        assert_eq!(top.merge(&top), top);
+        assert_eq!(taint.is_top(), false);
+    }
+
+    #[test]
+    fn register_domain() {
+        use crate::intermediate_representation::*;
+        let taint = Taint::Tainted(ByteSize::new(4));
+        let top = Taint::Top(ByteSize::new(4));
+        assert_eq!(taint.bin_op(BinOpType::IntAdd, &top), taint);
+        assert_eq!(top.bin_op(BinOpType::IntMult, &top), top);
+        assert_eq!(taint.un_op(UnOpType::FloatFloor), taint);
+        assert_eq!(taint.subpiece(ByteSize::new(0), ByteSize::new(4)), taint);
+        assert_eq!(top.cast(CastOpType::IntZExt, ByteSize::new(4)), top);
+    }
+}

--- a/cwe_checker_rs/src/checkers/cwe_560.rs
+++ b/cwe_checker_rs/src/checkers/cwe_560.rs
@@ -98,9 +98,10 @@ fn generate_cwe_warning(sub: &Term<Sub>, jmp: &Term<Jmp>, permission_const: u64)
 ///
 /// Only the basic block right before the umask call is evaluated when trying to determine the parameter value of umask.
 pub fn check_cwe(
-    project: &Project,
+    analysis_results: &AnalysisResults,
     _cwe_params: &serde_json::Value,
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
+    let project = analysis_results.project;
     let mut cwes = Vec::new();
     let mut log_messages = Vec::new();
     let umask_symbol_map = get_symbol_map(project, &["umask".to_string()]);

--- a/cwe_checker_rs/src/checkers/cwe_676.rs
+++ b/cwe_checker_rs/src/checkers/cwe_676.rs
@@ -18,10 +18,11 @@ False Negatives
 
 * None known
 */
+use crate::prelude::*;
 use std::collections::HashMap;
 
 use crate::{
-    intermediate_representation::{ExternSymbol, Program, Project, Sub, Term, Tid},
+    intermediate_representation::{ExternSymbol, Program, Sub, Term, Tid},
     utils::{
         log::{CweWarning, LogMessage},
         symbol_utils::get_calls_to_symbols,
@@ -106,9 +107,10 @@ pub fn resolve_symbols<'a>(
 }
 
 pub fn check_cwe(
-    project: &Project,
+    analysis_results: &AnalysisResults,
     cwe_params: &serde_json::Value,
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
+    let project = analysis_results.project;
     let config: Config = serde_json::from_value(cwe_params.clone()).unwrap();
     let prog: &Term<Program> = &project.program;
     let subfunctions: &Vec<Term<Sub>> = &prog.term.subs;

--- a/cwe_checker_rs/src/checkers/cwe_782.rs
+++ b/cwe_checker_rs/src/checkers/cwe_782.rs
@@ -14,10 +14,11 @@ False Negatives:
 
 * There are other ways to expose I/O control without access control.
 */
+use crate::prelude::*;
 use std::collections::HashMap;
 
 use crate::{
-    intermediate_representation::{Program, Project, Sub, Term, Tid},
+    intermediate_representation::{Program, Sub, Term, Tid},
     utils::{
         log::{CweWarning, LogMessage},
         symbol_utils::{find_symbol, get_calls_to_symbols},
@@ -66,9 +67,10 @@ pub fn generate_cwe_warning(calls: &[(&str, &Tid, &str)]) -> Vec<CweWarning> {
 }
 
 pub fn check_cwe(
-    project: &Project,
+    analysis_results: &AnalysisResults,
     _cwe_params: &serde_json::Value,
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
+    let project = analysis_results.project;
     let prog: &Term<Program> = &project.program;
     let mut warnings: Vec<CweWarning> = Vec::new();
     if let Some((tid, name)) = find_symbol(prog, "ioctl") {

--- a/cwe_checker_rs/src/ffi/analysis.rs
+++ b/cwe_checker_rs/src/ffi/analysis.rs
@@ -18,7 +18,7 @@ fn run_pointer_inference(program_jsonbuilder_val: ocaml::Value) -> (Vec<CweWarni
         serde_json::from_value(crate::utils::read_config_file("config.json")["Memory"].clone())
             .unwrap();
     let pi_analysis = crate::analysis::pointer_inference::run(&project, config, false);
-    let (mut logs, cwes) = pi_analysis.collected_logs.clone();
+    let (mut logs, cwes) = pi_analysis.collected_logs;
     all_logs.append(&mut logs);
     (
         cwes,

--- a/cwe_checker_rs/src/ffi/analysis.rs
+++ b/cwe_checker_rs/src/ffi/analysis.rs
@@ -17,7 +17,8 @@ fn run_pointer_inference(program_jsonbuilder_val: ocaml::Value) -> (Vec<CweWarni
     let config: crate::analysis::pointer_inference::Config =
         serde_json::from_value(crate::utils::read_config_file("config.json")["Memory"].clone())
             .unwrap();
-    let (mut logs, cwes) = crate::analysis::pointer_inference::run(&project, config, false);
+    let pi_analysis = crate::analysis::pointer_inference::run(&project, config, false);
+    let (mut logs, cwes) = pi_analysis.collected_logs.clone();
     all_logs.append(&mut logs);
     (
         cwes,

--- a/cwe_checker_rs/src/intermediate_representation/term.rs
+++ b/cwe_checker_rs/src/intermediate_representation/term.rs
@@ -331,6 +331,13 @@ impl Project {
     pub fn get_pointer_bytesize(&self) -> ByteSize {
         self.stack_pointer_register.size
     }
+
+    /// Try to guess a standard calling convention from the list of calling conventions in the project.
+    pub fn get_standard_calling_convention(&self) -> Option<&CallingConvention> {
+        self.calling_conventions
+            .iter()
+            .find(|cconv| cconv.name == "__stdcall")
+    }
 }
 
 impl Project {
@@ -436,6 +443,54 @@ impl Project {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    impl Blk {
+        pub fn mock() -> Term<Blk> {
+            Term {
+                tid: Tid::new("block"),
+                term: Blk {
+                    defs: Vec::new(),
+                    jmps: Vec::new(),
+                },
+            }
+        }
+    }
+
+    impl Sub {
+        pub fn mock(name: impl ToString) -> Term<Sub> {
+            Term {
+                tid: Tid::new(name.to_string()),
+                term: Sub {
+                    name: name.to_string(),
+                    blocks: Vec::new(),
+                },
+            }
+        }
+    }
+
+    impl Program {
+        pub fn mock_empty() -> Program {
+            Program {
+                subs: Vec::new(),
+                extern_symbols: Vec::new(),
+                entry_points: Vec::new(),
+            }
+        }
+    }
+
+    impl Project {
+        pub fn mock_empty() -> Project {
+            Project {
+                program: Term {
+                    tid: Tid::new("program_tid"),
+                    term: Program::mock_empty(),
+                },
+                cpu_architecture: "x86_64".to_string(),
+                stack_pointer_register: Variable::mock("RSP", 8u64),
+                calling_conventions: Vec::new(),
+            }
+        }
+    }
 
     #[test]
     fn retarget_nonexisting_jumps() {

--- a/cwe_checker_rs/src/intermediate_representation/variable.rs
+++ b/cwe_checker_rs/src/intermediate_representation/variable.rs
@@ -15,3 +15,18 @@ pub struct Variable {
     pub size: ByteSize,
     pub is_temp: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl Variable {
+        pub fn mock(name: impl ToString, size_in_bytes: impl Into<ByteSize>) -> Variable {
+            Variable {
+                name: name.to_string(),
+                size: size_in_bytes.into(),
+                is_temp: false,
+            }
+        }
+    }
+}

--- a/cwe_checker_rs/src/lib.rs
+++ b/cwe_checker_rs/src/lib.rs
@@ -7,6 +7,7 @@ Parts of the cwe_checker that are written in Rust.
 #[macro_use]
 extern crate ocaml;
 
+use crate::analysis::pointer_inference::PointerInference;
 use crate::intermediate_representation::Project;
 use crate::utils::log::{CweWarning, LogMessage};
 
@@ -27,11 +28,13 @@ mod prelude {
     pub use crate::bil::{BitSize, Bitvector};
     pub use crate::intermediate_representation::ByteSize;
     pub use crate::intermediate_representation::{Term, Tid};
+    pub use crate::AnalysisResults;
     pub use anyhow::{anyhow, Error};
 }
 
 /// The generic function signature for the main function of a CWE module
-pub type CweModuleFn = fn(&Project, &serde_json::Value) -> (Vec<LogMessage>, Vec<CweWarning>);
+pub type CweModuleFn =
+    fn(&AnalysisResults, &serde_json::Value) -> (Vec<LogMessage>, Vec<CweWarning>);
 
 /// A structure containing general information about a CWE analysis module,
 /// including the function to be called to run the analysis.
@@ -55,9 +58,51 @@ pub fn get_modules() -> Vec<&'static CweModule> {
         &crate::checkers::cwe_332::CWE_MODULE,
         &crate::checkers::cwe_426::CWE_MODULE,
         &crate::checkers::cwe_467::CWE_MODULE,
+        &crate::checkers::cwe_476::CWE_MODULE,
         &crate::checkers::cwe_560::CWE_MODULE,
-        &crate::checkers::cwe_782::CWE_MODULE,
         &crate::checkers::cwe_676::CWE_MODULE,
+        &crate::checkers::cwe_782::CWE_MODULE,
         &crate::analysis::pointer_inference::CWE_MODULE,
     ]
+}
+
+/// A struct containing pointers to all known analysis results
+/// that may be needed as input for other analyses and CWE checks.
+#[derive(Clone, Copy)]
+pub struct AnalysisResults<'a> {
+    /// A pointer to the project struct
+    pub project: &'a Project,
+    /// The result of the pointer inference analysis if already computed.
+    pub pointer_inference: Option<&'a PointerInference<'a>>,
+}
+
+impl<'a> AnalysisResults<'a> {
+    /// Create a new `AnalysisResults` struct with only the project itself known.
+    pub fn new(project: &'a Project) -> AnalysisResults<'a> {
+        AnalysisResults {
+            project,
+            pointer_inference: None,
+        }
+    }
+
+    /// Compute the pointer inference analysis.
+    /// The result gets returned, but not saved to the `AnalysisResults` struct itself.
+    pub fn compute_pointer_inference(&self, config: &serde_json::Value) -> PointerInference<'a> {
+        crate::analysis::pointer_inference::run(
+            self.project,
+            serde_json::from_value(config.clone()).unwrap(),
+            false,
+        )
+    }
+
+    /// Create a new `AnalysisResults` struct containing the given pointer inference analysis results.
+    pub fn set_pointer_inference<'b: 'a>(
+        self,
+        pi_results: Option<&'b PointerInference<'a>>,
+    ) -> AnalysisResults<'b> {
+        AnalysisResults {
+            pointer_inference: pi_results,
+            ..self
+        }
+    }
 }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -363,6 +363,35 @@ mod tests {
 
     #[test]
     #[ignore]
+    fn cwe_476() {
+        let mut error_log = Vec::new();
+        let mut tests = all_test_cases("cwe_476", "CWE476");
+
+        // TODO: Check reason for failure!
+        mark_skipped(&mut tests, "mips64", "gcc");
+        mark_skipped(&mut tests, "mips64el", "gcc");
+        mark_skipped(&mut tests, "mips", "gcc");
+        mark_skipped(&mut tests, "mipsel", "gcc");
+
+        mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
+        mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
+
+        mark_compiler_skipped(&mut tests, "mingw32-gcc"); // TODO: Check reason for failure!
+
+        for test_case in tests {
+            let num_expected_occurences = 1;
+            if let Err(error) = test_case.run_test("[CWE476]", num_expected_occurences) {
+                error_log.push((test_case.get_filepath(), error));
+            }
+        }
+        if !error_log.is_empty() {
+            print_errors(error_log);
+            panic!();
+        }
+    }
+
+    #[test]
+    #[ignore]
     fn cwe_560() {
         let mut error_log = Vec::new();
         let mut tests = linux_test_cases("cwe_560", "CWE560");


### PR DESCRIPTION
This PR reimplements the CWE 476 (Null Pointer Dereference) check in Rust. 

It also contains some improvements to logging and unit tests that probably should have been put into a separate PR.