### PR TITLE
more exact address reporting for CWE 676

### DIFF
--- a/src/checkers/cwe_676.ml
+++ b/src/checkers/cwe_676.ml
@@ -13,7 +13,7 @@ let get_call_to_target _cg callee target =
            | Goto _ | Ret _ | Int (_,_) -> None
            | Call dst -> match Call.target dst with
              | Direct tid when tid = (Term.tid target) ->
-               Some (Term.name callee, Term.tid blk, Term.name target)
+               Some (Term.name callee, Term.tid j, Term.name target)
              | _ -> None))
 
 let get_calls_to_symbols cg subfunctions symbols =


### PR DESCRIPTION
Report the exact address of the call and not only of the basic block containing the call for CWE 676 (with BAP backend).