### PR TITLE
Cwe476 parameter checks

### DIFF
--- a/cwe_checker_rs/src/abstract_domain/mem_region.rs
+++ b/cwe_checker_rs/src/abstract_domain/mem_region.rs
@@ -144,6 +144,15 @@ impl<T: AbstractDomain + HasByteSize + RegisterDomain + std::fmt::Debug> MemRegi
         T::new_top(size_in_bytes)
     }
 
+    /// Get the value at the given position regardless of the value size.
+    /// Return `None` if there is no value at that position in the memory region.
+    pub fn get_unsized(&self, position: Bitvector) -> Option<T> {
+        assert_eq!(ByteSize::from(position.width()), self.address_bytesize);
+        let position = Int::from(position).try_to_i64().unwrap();
+
+        self.values.get(&position).cloned()
+    }
+
     /// Remove all elements intersecting the provided interval.
     pub fn remove(&mut self, position: Bitvector, size_in_bytes: Bitvector) {
         assert_eq!(ByteSize::from(position.width()), self.address_bytesize);

--- a/cwe_checker_rs/src/analysis/pointer_inference/mod.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/mod.rs
@@ -25,7 +25,7 @@ use petgraph::Direction;
 use std::collections::HashMap;
 
 mod context;
-mod object;
+pub mod object;
 mod object_list;
 mod state;
 

--- a/cwe_checker_rs/src/analysis/pointer_inference/object.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/object.rs
@@ -159,6 +159,11 @@ impl AbstractObjectInfo {
         self.state
     }
 
+    /// Get the type of the memory object.
+    pub fn get_object_type(&self) -> Option<ObjectType> {
+        self.type_
+    }
+
     /// Invalidates all memory and adds the `additional_targets` to the pointer targets.
     /// Represents the effect of unknown write instructions to the object
     /// which may include writing pointers to targets from the `additional_targets` set to the object.

--- a/cwe_checker_rs/src/analysis/pointer_inference/object_list.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/object_list.rs
@@ -275,6 +275,15 @@ impl AbstractObjectList {
             object.remove_ids(ids_to_remove);
         }
     }
+
+    // Return the object type of a memory object.
+    // Returns an error if no object with the given ID is contained in the object list.
+    pub fn get_object_type(&self, object_id: &AbstractIdentifier) -> Result<Option<ObjectType>, ()> {
+        match self.objects.get(object_id) {
+            Some((object, _)) => Ok(object.get_object_type()),
+            None => Err(()),
+        }
+    }
 }
 
 impl AbstractDomain for AbstractObjectList {

--- a/cwe_checker_rs/src/analysis/pointer_inference/object_list.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/object_list.rs
@@ -278,7 +278,10 @@ impl AbstractObjectList {
 
     // Return the object type of a memory object.
     // Returns an error if no object with the given ID is contained in the object list.
-    pub fn get_object_type(&self, object_id: &AbstractIdentifier) -> Result<Option<ObjectType>, ()> {
+    pub fn get_object_type(
+        &self,
+        object_id: &AbstractIdentifier,
+    ) -> Result<Option<ObjectType>, ()> {
         match self.objects.get(object_id) {
             Some((object, _)) => Ok(object.get_object_type()),
             None => Err(()),

--- a/cwe_checker_rs/src/checkers/cwe_476/state.rs
+++ b/cwe_checker_rs/src/checkers/cwe_476/state.rs
@@ -5,7 +5,7 @@ use crate::analysis::pointer_inference::Data;
 use crate::analysis::pointer_inference::State as PointerInferenceState;
 use crate::intermediate_representation::*;
 use crate::prelude::*;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 
 use super::Taint;
 
@@ -222,11 +222,44 @@ impl State {
         }
     }
 
-    pub fn check_mem_ids_for_taint(&self, ids: &BTreeSet<AbstractIdentifier>) -> bool {
-        for id in ids {
-            if let Some(mem_object) = self.memory_taint.get(&id) {
-                for elem in mem_object.values() {
-                    if elem.is_tainted() {
+    /// Return true if the memory object with the given ID contains a tainted value.
+    pub fn check_mem_id_for_taint(&self, id: &AbstractIdentifier) -> bool {
+        if let Some(mem_object) = self.memory_taint.get(&id) {
+            for elem in mem_object.values() {
+                if elem.is_tainted() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// If the given address points to the stack,
+    /// return true if and only if the value at that tsack position is tainted.
+    /// If the given address points to a non-stack memory object,
+    /// return true if the memory object contains any tainted value (at any position).
+    pub fn check_if_address_points_to_taint(
+        &self,
+        address: Data,
+        pi_state: &PointerInferenceState,
+    ) -> bool {
+        use crate::analysis::pointer_inference::object::ObjectType;
+        if let Data::Pointer(pointer) = address {
+            for (target, offset) in pointer.targets() {
+                if let Ok(Some(ObjectType::Stack)) = pi_state.memory.get_object_type(target) {
+                    // Only check if the value at the address is tainted
+                    if let (Some(mem_object), BitvectorDomain::Value(target_offset)) =
+                        (self.memory_taint.get(target), offset)
+                    {
+                        if let Some(taint) = mem_object.get_unsized(target_offset.clone()) {
+                            if taint.is_tainted() {
+                                return true;
+                            }
+                        }
+                    }
+                } else {
+                    // Check whether the memory object contains any taint.
+                    if self.check_mem_id_for_taint(target) {
                         return true;
                     }
                 }
@@ -235,10 +268,13 @@ impl State {
         false
     }
 
-    /// Check whether a register in the given register list contains taint
-    /// or (recursively) references a memory object containing taint.
+    /// Check whether a register in the given register list contains taint.
     /// Return `true` if taint was found and `false` if no taint was found.
-    fn check_register_list_recursively_for_taint(&self, register_list: &[String], pi_state_option: Option<&PointerInferenceState>) -> bool {
+    fn check_register_list_for_taint(
+        &self,
+        register_list: &[String],
+        pi_state_option: Option<&PointerInferenceState>,
+    ) -> bool {
         // Check whether a register contains taint
         for (register, taint) in &self.register_taint {
             if register_list
@@ -249,20 +285,14 @@ impl State {
                 return true;
             }
         }
-        // Check whether some memory object (recursively) referenced by a register may contain taint
+        // Check whether some memory object referenced by a register may contain taint
         if let Some(pi_state) = pi_state_option {
-            let mut possible_referenced_ids = BTreeSet::new();
             for register_name in register_list {
-                if let Some(register_value) =
-                    pi_state.get_register_by_name(register_name)
-                {
-                    possible_referenced_ids.append(&mut register_value.referenced_ids());
+                if let Some(register_value) = pi_state.get_register_by_name(register_name) {
+                    if self.check_if_address_points_to_taint(register_value, pi_state) {
+                        return true;
+                    }
                 }
-            }
-            possible_referenced_ids = pi_state
-                .add_recursively_referenced_ids_to_id_set(possible_referenced_ids);
-            if self.check_mem_ids_for_taint(&possible_referenced_ids) {
-                return true;
             }
         }
         false
@@ -271,9 +301,16 @@ impl State {
     /// Check whether a generic function call may contain tainted values in its parameters.
     /// Since we don't know the actual calling convention of the call,
     /// we approximate the parameters with all parameter registers of the standard calling convention of the project.
-    pub fn check_generic_function_params_for_taint(&self, project: &Project, pi_state_option: Option<&PointerInferenceState>) -> bool {
+    pub fn check_generic_function_params_for_taint(
+        &self,
+        project: &Project,
+        pi_state_option: Option<&PointerInferenceState>,
+    ) -> bool {
         if let Some(calling_conv) = project.get_standard_calling_convention() {
-            self.check_register_list_recursively_for_taint(&calling_conv.parameter_register[..], pi_state_option)
+            self.check_register_list_for_taint(
+                &calling_conv.parameter_register[..],
+                pi_state_option,
+            )
         } else {
             // No standard calling convention found. Assume everything may be parameters or referenced by parameters.
             !self.is_empty()
@@ -283,9 +320,13 @@ impl State {
     /// Check whether the return registers may contain tainted values or point to objects containing tainted values.
     /// Since we don't know the actual return registers,
     /// we approximate them by all return registers of the standard calling convention of the project.
-    pub fn check_return_values_for_taint(&self, project: &Project, pi_state_option: Option<&PointerInferenceState>) -> bool {
+    pub fn check_return_values_for_taint(
+        &self,
+        project: &Project,
+        pi_state_option: Option<&PointerInferenceState>,
+    ) -> bool {
         if let Some(calling_conv) = project.get_standard_calling_convention() {
-            self.check_register_list_recursively_for_taint(&calling_conv.return_register[..], pi_state_option)
+            self.check_register_list_for_taint(&calling_conv.return_register[..], pi_state_option)
         } else {
             // No standard calling convention found. Assume everything may be return values or referenced by return values.
             !self.is_empty()

--- a/cwe_checker_rs/src/checkers/cwe_476/state.rs
+++ b/cwe_checker_rs/src/checkers/cwe_476/state.rs
@@ -235,7 +235,7 @@ impl State {
     }
 
     /// If the given address points to the stack,
-    /// return true if and only if the value at that tsack position is tainted.
+    /// return true if and only if the value at that stack position is tainted.
     /// If the given address points to a non-stack memory object,
     /// return true if the memory object contains any tainted value (at any position).
     pub fn check_if_address_points_to_taint(

--- a/cwe_checker_rs/src/intermediate_representation/term.rs
+++ b/cwe_checker_rs/src/intermediate_representation/term.rs
@@ -484,8 +484,7 @@ mod tests {
                 name: "__stdcall".to_string(), // so that the mock is useable as standard calling convention in tests
                 parameter_register: vec!["RDI".to_string()],
                 return_register: vec!["RAX".to_string()],
-                callee_saved_register: vec!["RBP".to_string()]
-
+                callee_saved_register: vec!["RBP".to_string()],
             }
         }
     }

--- a/cwe_checker_rs/src/intermediate_representation/term.rs
+++ b/cwe_checker_rs/src/intermediate_representation/term.rs
@@ -478,6 +478,38 @@ mod tests {
         }
     }
 
+    impl CallingConvention {
+        pub fn mock() -> CallingConvention {
+            CallingConvention {
+                name: "__stdcall".to_string(), // so that the mock is useable as standard calling convention in tests
+                parameter_register: vec!["RDI".to_string()],
+                return_register: vec!["RAX".to_string()],
+                callee_saved_register: vec!["RBP".to_string()]
+
+            }
+        }
+    }
+
+    impl Arg {
+        pub fn mock_register(name: impl ToString) -> Arg {
+            Arg::Register(Variable::mock(name.to_string(), ByteSize::new(8)))
+        }
+    }
+
+    impl ExternSymbol {
+        pub fn mock() -> ExternSymbol {
+            ExternSymbol {
+                tid: Tid::new("mock_symbol"),
+                addresses: vec!["UNKNOWN".to_string()],
+                name: "mock_symbol".to_string(),
+                calling_convention: Some("__stdcall".to_string()),
+                parameters: vec![Arg::mock_register("RDI")],
+                return_values: vec![Arg::mock_register("RAX")],
+                no_return: false,
+            }
+        }
+    }
+
     impl Project {
         pub fn mock_empty() -> Project {
             Project {


### PR DESCRIPTION
This PR adjusts how CWE hits are detected on function calls and function returns to reduce false positives.

For pointers to the stack as parameters, we underapproximate the values that the call may access to reduce false positives.
For pointers to the heap as parameters, we flag if any possible NULL pointer is contained in the target memory object.