### PR TITLE
Add the POPCOUNT  expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ Just run `make all` to compile and register the plugin with BAP. You can run the
 
 ### Local installation with Ghidra as backend ###
 
-The Ghidra backend is still in early development, thus many checks are not yet available for it. To try it out, the following dependencies must be fulfilled:
+The Ghidra backend is still in early development, thus some checks are not yet available for it. To try it out, the following dependencies must be fulfilled:
 -   [Rust](https://www.rust-lang.org) >= 1.44.1
--   Ghidra >= 9.1
--   The Java library `gson`. Download it from https://search.maven.org/artifact/com.google.code.gson/gson/2.8.6/jar and move it to the Ghidra plugin folder located at `$HOME/.ghidra/.ghidra_9.X.X_PUBLIC/plugins` (with the version number depending on your version of Ghidra).
+-   [Ghidra](https://ghidra-sre.org/) >= 9.2. If you want to use an earlier version of Ghidra, you need to manually add the Java library `gson` to Ghidra: Download it from https://search.maven.org/artifact/com.google.code.gson/gson/2.8.6/jar and move it to the Ghidra plugin folder located at `$HOME/.ghidra/.ghidra_9.X.X_PUBLIC/plugins` (with the version number depending on your version of Ghidra).
 
 Run `make all GHIDRA_PATH=path/to/ghidra_folder` (with the correct path to the local Ghidra installation inserted) to compile and install the *cwe_checker*.
 

--- a/cwe_checker_rs/src/abstract_domain/bitvector.rs
+++ b/cwe_checker_rs/src/abstract_domain/bitvector.rs
@@ -265,6 +265,11 @@ impl RegisterDomain for BitvectorDomain {
                         .into_sign_extend(apint::BitWidth::from(width))
                         .unwrap(),
                 ),
+                PopCount => BitvectorDomain::Value(
+                    Bitvector::from_u64(bitvec.count_ones() as u64)
+                        .into_truncate(apint::BitWidth::from(width))
+                        .unwrap(),
+                ),
                 Int2Float | Float2Float | Trunc => BitvectorDomain::new_top(width),
             }
         } else {
@@ -338,6 +343,7 @@ mod tests {
     #[test]
     fn bitvector_domain_as_value_domain() {
         use BinOpType::*;
+        use CastOpType::*;
         use UnOpType::*;
         let eight = bv(8);
         let sixteen = bv(16);
@@ -388,6 +394,11 @@ mod tests {
                 .bin_op(Piece, &BitvectorDomain::Value(Bitvector::from_i32(-1))),
             bv(-1)
         );
+
+        assert_eq!(
+            BitvectorDomain::Value(Bitvector::from_i32(-1)).cast(PopCount, ByteSize::new(8)),
+            bv(32)
+        )
     }
 
     #[test]

--- a/cwe_checker_rs/src/intermediate_representation/expression.rs
+++ b/cwe_checker_rs/src/intermediate_representation/expression.rs
@@ -181,6 +181,7 @@ pub enum CastOpType {
     Int2Float,
     Float2Float,
     Trunc,
+    PopCount,
 }
 
 /// The type/mnemonic of an unary operation

--- a/cwe_checker_rs/src/pcode/expressions.rs
+++ b/cwe_checker_rs/src/pcode/expressions.rs
@@ -129,7 +129,7 @@ impl From<Expression> for IrExpression {
     /// Cases where translation is not possible:
     /// - `LOAD` and `STORE`, since these are not expressions (they have side effects).
     /// - Expressions which store the size of their output in the output variable (to which we do not have access here).
-    /// These include `SUBPIECE`, `INT_ZEXT`, `INT_SEXT`, `INT2FLOAT`, `FLOAT2FLOAT` and `TRUNC`.
+    /// These include `SUBPIECE`, `INT_ZEXT`, `INT_SEXT`, `INT2FLOAT`, `FLOAT2FLOAT`, `TRUNC` and `POPCOUNT`.
     /// Translation of these expressions is handled explicitly during translation of `Def`.
     fn from(expr: Expression) -> IrExpression {
         use ExpressionType::*;
@@ -151,7 +151,7 @@ impl From<Expression> for IrExpression {
                 op: expr.mnemonic.into(),
                 arg: Box::new(expr.input0.unwrap().into()),
             },
-            INT_ZEXT | INT_SEXT | INT2FLOAT | FLOAT2FLOAT | TRUNC => panic!(),
+            INT_ZEXT | INT_SEXT | INT2FLOAT | FLOAT2FLOAT | TRUNC | POPCOUNT => panic!(),
         }
     }
 }
@@ -164,6 +164,7 @@ pub enum ExpressionType {
     STORE,
     PIECE,
     SUBPIECE,
+    POPCOUNT,
 
     INT_EQUAL,
     INT_NOTEQUAL,
@@ -310,6 +311,7 @@ impl From<ExpressionType> for IrCastOpType {
             INT2FLOAT => IrCastOpType::Int2Float,
             FLOAT2FLOAT => IrCastOpType::Float2Float,
             TRUNC => IrCastOpType::Trunc,
+            POPCOUNT => IrCastOpType::PopCount,
             _ => panic!(),
         }
     }

--- a/cwe_checker_rs/src/pcode/term.rs
+++ b/cwe_checker_rs/src/pcode/term.rs
@@ -141,7 +141,7 @@ impl From<Def> for IrDef {
                     arg: Box::new(def.rhs.input0.unwrap().into()),
                 },
             },
-            INT_ZEXT | INT_SEXT | INT2FLOAT | FLOAT2FLOAT | TRUNC => IrDef::Assign {
+            INT_ZEXT | INT_SEXT | INT2FLOAT | FLOAT2FLOAT | TRUNC | POPCOUNT => IrDef::Assign {
                 var: def.lhs.clone().unwrap().into(),
                 value: IrExpression::Cast {
                     op: def.rhs.mnemonic.into(),


### PR DESCRIPTION
This PR adds support for the POPCOUNT P-Code instruction introduced in Ghidra 9.2.

As a side effect, we are now fully compatible to Ghidra 9.2 and since Ghidra now includes the Gson library, one does not need to manually add it to Ghidra when installing the cwe_checker.