### PR TITLE
Cwe215

### DIFF
--- a/cwe_checker_rs/Cargo.toml
+++ b/cwe_checker_rs/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0" # for easy error types
 crossbeam-channel = "0.4"
 derive_more = "0.99"
 directories = "3.0"
+goblin = "0.2"
 
 [lib]
 name = "cwe_checker_rs"

--- a/cwe_checker_rs/src/checkers.rs
+++ b/cwe_checker_rs/src/checkers.rs
@@ -1,4 +1,5 @@
 pub mod cwe_190;
+pub mod cwe_215;
 pub mod cwe_332;
 pub mod cwe_367;
 pub mod cwe_426;

--- a/cwe_checker_rs/src/checkers/cwe_215.rs
+++ b/cwe_checker_rs/src/checkers/cwe_215.rs
@@ -1,0 +1,70 @@
+//! This module implements a check for CWE-215: Information Exposure Through Debug Information.
+//!
+//! Sensitive debugging information can be leveraged to get a better understanding
+//! of a binary in less time.
+//!
+//! See <https://cwe.mitre.org/data/definitions/215.html> for a detailed description.
+//!
+//! ## How the check works
+//!
+//! For ELF binaries we check whether they contain sections containing debug information.
+//! Other binary formats are currently not supported by this check.
+//!
+//! ## False Positives
+//!
+//! None known.
+//!
+//! ## False Negatives
+//!
+//! None known.
+
+use crate::prelude::*;
+use crate::utils::log::{CweWarning, LogMessage};
+use crate::CweModule;
+
+pub static CWE_MODULE: CweModule = CweModule {
+    name: "CWE215",
+    version: "0.2",
+    run: check_cwe,
+};
+
+/// Run the check.
+///
+/// We simply check whether the ELF file still contains sections whose name starts with `.debug`.
+/// Binary formats other than ELF files are currently not supported by this check.
+pub fn check_cwe(
+    analysis_results: &AnalysisResults,
+    _cwe_params: &serde_json::Value,
+) -> (Vec<LogMessage>, Vec<CweWarning>) {
+    let binary = analysis_results.binary;
+
+    match goblin::Object::parse(binary) {
+        Ok(goblin::Object::Elf(elf_binary)) => {
+            for section_header in elf_binary.section_headers {
+                if let Some(Ok(section_name)) = elf_binary.shdr_strtab.get(section_header.sh_name) {
+                    if section_name.starts_with(".debug") {
+                        let cwe_warning = CweWarning::new(
+                            CWE_MODULE.name,
+                            CWE_MODULE.version,
+                            "(Information Exposure Through Debug Information) The binary contains debug symbols."
+                        );
+                        return (Vec::new(), vec![cwe_warning]);
+                    }
+                }
+            }
+            (Vec::new(), Vec::new())
+        }
+        Ok(_) => {
+            let info_log = LogMessage::new_info(
+                "File type not supported. Currently this check only supports ELF files.",
+            )
+            .source(CWE_MODULE.name);
+            (vec![info_log], Vec::new())
+        }
+        Err(err) => {
+            let err_log = LogMessage::new_error(format!("Error while parsing binary: {}", err))
+                .source(CWE_MODULE.name);
+            (vec![err_log], Vec::new())
+        }
+    }
+}

--- a/cwe_checker_rs/src/lib.rs
+++ b/cwe_checker_rs/src/lib.rs
@@ -55,6 +55,7 @@ impl std::fmt::Display for CweModule {
 pub fn get_modules() -> Vec<&'static CweModule> {
     vec![
         &crate::checkers::cwe_190::CWE_MODULE,
+        &crate::checkers::cwe_215::CWE_MODULE,
         &crate::checkers::cwe_332::CWE_MODULE,
         &crate::checkers::cwe_367::CWE_MODULE,
         &crate::checkers::cwe_426::CWE_MODULE,
@@ -71,6 +72,8 @@ pub fn get_modules() -> Vec<&'static CweModule> {
 /// that may be needed as input for other analyses and CWE checks.
 #[derive(Clone, Copy)]
 pub struct AnalysisResults<'a> {
+    /// The content of the binary file
+    pub binary: &'a [u8],
     /// A pointer to the project struct
     pub project: &'a Project,
     /// The result of the pointer inference analysis if already computed.
@@ -79,8 +82,9 @@ pub struct AnalysisResults<'a> {
 
 impl<'a> AnalysisResults<'a> {
     /// Create a new `AnalysisResults` struct with only the project itself known.
-    pub fn new(project: &'a Project) -> AnalysisResults<'a> {
+    pub fn new(binary: &'a [u8], project: &'a Project) -> AnalysisResults<'a> {
         AnalysisResults {
+            binary,
             project,
             pointer_inference: None,
         }

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -200,6 +200,24 @@ mod tests {
 
     #[test]
     #[ignore]
+    fn cwe_215() {
+        let mut error_log = Vec::new();
+        let tests = linux_test_cases("cwe_476", "CWE215"); // We use the test binaries of another check here.
+
+        for test_case in tests {
+            let num_expected_occurences = 1;
+            if let Err(error) = test_case.run_test("[CWE215]", num_expected_occurences) {
+                error_log.push((test_case.get_filepath(), error));
+            }
+        }
+        if !error_log.is_empty() {
+            print_errors(error_log);
+            panic!();
+        }
+    }
+
+    #[test]
+    #[ignore]
     fn cwe_332() {
         let mut error_log = Vec::new();
         let mut tests = all_test_cases("cwe_332", "CWE332");


### PR DESCRIPTION
This PR reimplements the check for CWE 215 (Information exposure through debug information) in Rust for usage with the Ghidra backend.