### PR TITLE
Ocaml 4.8

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-dev
+0.4 (2021-01)
 ====
 
 -   Added a lot more test cases to acceptance tests (PR #46)
@@ -11,6 +11,10 @@ dev
 -   Several code improvements to for the CWE 415 and 416 checks (PRs #76, #77. #78, #84)
 -   Report more accurate incident locations for CWE 476 (PR #80)
 -   Enable Ghidra as an alternative Backend to BAP (still experimental) (PRs #86, #87)
+-   Added acceptance tests for the Ghidra backend (PRs #91, #99)
+-   Bugfixes for the Ghidra backend (PRs #98, #101, #104, #106, #110, #114, #120)
+-   Ported the CWE checks to Rust for the Ghidra backend (PRs #88, #95, #100, #102, #111, #117, #119, #121)
+-   Added support for Ghidra 9.2 (PR #116)
 
 0.3 (2019-12)
 ====

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ If you want to build the docker image yourself, just run `docker build -t cwe_ch
 Another way is to get cwe_checker from the Ocaml package manager Opam. You can install cwe_checker via the package [cwe_checker](https://opam.ocaml.org/packages/cwe_checker/) (`opam install cwe_checker`). This gives you the latest stable release version of the  *cwe_checker*.
 
 If you plan to develop *cwe_checker*, it is recommended to build it using the provided `Makefile`. In this case you must ensure that all dependencies are fulfilled:
--   Ocaml 4.07.1
+-   Ocaml 4.08.0
 -   Opam 2.0.2
 -   dune >= 2.0
--   BAP (and its dependencies). Development on the master branch depends on the master branch of BAP which can be added with `opam repo add bap-testing git+https://github.com/BinaryAnalysisPlatform/opam-repository#testing` to the sources of the Opam package manager. The stable release of the *cwe_checker* depends on BAP 1.6.
+-   BAP 2.2.0 (and its dependencies).
 -   yojson >= 1.6.0
 -   ppx_deriving_yojson >= 3.5.1
 -   alcotest >= 0.8.3 (for tests)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## What is cwe_checker? ##
 *cwe_checker* is a suite of tools to detect common bug classes such as use of dangerous functions and simple integer overflows. These bug classes are formally known as [Common Weakness Enumerations](https://cwe.mitre.org/) (CWEs). Its main goal is to aid analysts to quickly find vulnerable code paths.
 
-Its main focus are ELF binaries that are commonly found on Linux and Unix operating systems. *cwe_checker* is built on top of [BAP](https://github.com/BinaryAnalysisPlatform/bap) (Binary Analysis Platform). By using BAP, we are not restricted to one low level instruction set architectures like Intel x86. BAP lifts several of them to one common intermediate representation (IR). cwe_checker implements its analyses on this IR. At time of writing, BAP 2.1 supports Intel x86/x64, ARM, MIPS, and PPC amongst others. Hence, this makes *cwe_checker* a valuable tool for firmware analysis.
+Its main focus are ELF binaries that are commonly found on Linux and Unix operating systems. *cwe_checker* is built on top of [BAP](https://github.com/BinaryAnalysisPlatform/bap) (Binary Analysis Platform). By using BAP, we are not restricted to one low level instruction set architectures like Intel x86. BAP lifts several of them to one common intermediate representation (IR). cwe_checker implements its analyses on this IR. At time of writing, BAP 2.2 supports Intel x86/x64, ARM, MIPS, and PPC amongst others. Hence, this makes *cwe_checker* a valuable tool for firmware analysis.
 
 The following arguments should convince you to give *cwe_checker* a try:
 -  it is very easy to set up, just build the Docker container!
@@ -32,8 +32,6 @@ The simplest way is to pull the latest Docker image from [dockerhub](https://hub
 If you want to build the docker image yourself, just run `docker build -t cwe_checker .`
 
 ### Local installation with BAP as backend ###
-
-Another way is to get cwe_checker from the Ocaml package manager Opam. You can install cwe_checker via the package [cwe_checker](https://opam.ocaml.org/packages/cwe_checker/) (`opam install cwe_checker`). This gives you the latest stable release version of the  *cwe_checker*.
 
 If you plan to develop *cwe_checker*, it is recommended to build it using the provided `Makefile`. In this case you must ensure that all dependencies are fulfilled:
 -   Ocaml 4.08.0

--- a/caller/Cargo.toml
+++ b/caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cwe_checker"
-version = "0.4.0-dev"
+version = "0.4.0"
 authors = ["Enkelmann <nils-edvin.enkelmann@fkie.fraunhofer.de>"]
 edition = "2018"
 

--- a/cwe_checker.opam
+++ b/cwe_checker.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "cwe_checker"
-version: "0.3"
+version: "0.4"
 synopsis: "BAP plugin collection to detect common bug classes"
 description: """
 cwe_checker is a suite of tools to detect common bug classes such as use of dangerous functions and simple integer overflows. These bug classes are formally known as Common Weakness Enumerations (CWEs).
@@ -12,13 +12,13 @@ homepage: "https://github.com/fkie-cad/cwe_checker"
 bug-reports: "https://github.com/fkie-cad/cwe_checker/issues"
 dev-repo: "git+https://github.com/fkie-cad/cwe_checker"
 depends: [
-  "ocaml" {>= "4.07.1"}
-  "dune" {>= "1.6"}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
   "yojson" {>= "1.6.0"}
-  "bap" {>= "2.0"}
+  "bap" {>= "2.2.0"}
   "alcotest" {>= "0.8.3"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
-  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "core_kernel" {>= "v0.14"}
+  "ppx_jane" {>= "v0.14"}
   "ppx_deriving_yojson" {>= "3.5.1"}
   "odoc" {>= "1.4"}
 ]

--- a/cwe_checker_rs/Cargo.toml
+++ b/cwe_checker_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cwe_checker_rs"
-version = "0.4.0-dev"
+version = "0.4.0"
 authors = ["Nils-Edvin Enkelmann <nils-edvin.enkelmann@fkie.fraunhofer.de>"]
 edition = "2018"
 

--- a/plugins/cwe_checker_emulation/cwe_checker_emulation.ml
+++ b/plugins/cwe_checker_emulation/cwe_checker_emulation.ml
@@ -85,7 +85,7 @@ let rec run = function
     Machine.current () >>= fun pid ->
     Machine.fork ()    >>= fun () ->
     Machine.current () >>= fun cid ->
-    if pid = cid
+    if Poly.(=) pid cid
     then run xs
     else
       exec x >>= fun () ->
@@ -95,7 +95,7 @@ let rec run = function
 (** Checks if a certain Primus.Observation.Provider is equal
     to a string like 'incident'. *)
 let has_name name p =
-  Primus.Observation.Provider.name p = name
+  Poly.(=) (Primus.Observation.Provider.name p) name
 
 (** Register a monitor. *)
 let monitor_provider name ps =

--- a/src/analysis/check_path.ml
+++ b/src/analysis/check_path.ml
@@ -14,7 +14,7 @@ type proof =
 
 (** Taken from https://stackoverflow.com/questions/8373460/substring-check-in-ocaml *)
 let contains_substring search target =
-    String.substr_index ~pattern:search target <> None
+    Option.is_some (String.substr_index ~pattern:search target)
 
 let format_path get_source get_destination path tid_map =
   let e_count = List.length (Seq.to_list (Path.edges path)) in
@@ -78,7 +78,7 @@ let block_has_callsite blk t =
         match Jmp.kind j with
         | Goto _ | Ret _ | Int (_,_) -> false 
         | Call destination -> begin match Call.target destination with
-                              | Direct tid -> tid = t
+                              | Direct tid -> Tid.(=) tid t
                               | _ -> false
                               end)
 
@@ -90,11 +90,11 @@ let collect_callsites program t =
 
 let sub_has_tid sub tid =
   Term.enum blk_t sub
-  |> Seq.exists ~f:(fun blk -> Term.tid blk = tid || Blk.elts blk
+  |> Seq.exists ~f:(fun blk -> Tid.(=) (Term.tid blk) tid || Blk.elts blk
                                |> Seq.exists ~f:(fun e -> match e with
-                                                          | `Def d -> Term.tid d = tid
-                                                          | `Jmp j -> Term.tid j = tid
-                                                          | `Phi p -> Term.tid p = tid ))
+                                                          | `Def d -> Tid.(=) (Term.tid d) tid
+                                                          | `Jmp j -> Tid.(=) (Term.tid j) tid
+                                                          | `Phi p -> Tid.(=) (Term.tid p) tid ))
 
 let find_sub_tid_of_term_tid program tid =
   match tid with

--- a/src/analysis/mem_region.ml
+++ b/src/analysis/mem_region.ml
@@ -108,8 +108,8 @@ let rec mark_error mem_region ~pos ~size =
     else if pos + size <= hd.pos then
       (error_elem ~pos ~size) :: mem_region
     else
-      let start_pos = min pos hd.pos in
-      let end_pos_plus_one = max (pos + size) (hd.pos + hd.size) in
+      let start_pos = Word.min pos hd.pos in
+      let end_pos_plus_one = Word.max (pos + size) (hd.pos + hd.size) in
       mark_error tl ~pos:start_pos ~size:(end_pos_plus_one - start_pos)
 
 
@@ -133,8 +133,8 @@ let rec merge mem_region1 mem_region2 ~data_merge =
         end
       | _ -> { hd1 with data = Error(()) } :: merge tl1 tl2 ~data_merge
     else
-      let start_pos = min hd1.pos hd2.pos in
-      let end_pos_plus_one = max (hd1.pos + hd1.size) (hd2.pos + hd2.size) in
+      let start_pos = Word.min hd1.pos hd2.pos in
+      let end_pos_plus_one = Word.max (hd1.pos + hd1.size) (hd2.pos + hd2.size) in
       let mem_region = merge tl1 tl2 ~data_merge in
       mark_error mem_region ~pos:start_pos ~size:(end_pos_plus_one - start_pos)
 

--- a/src/checkers/cwe_215.ml
+++ b/src/checkers/cwe_215.ml
@@ -25,7 +25,7 @@ let check_cwe _ project _ _ _ =
   | Some fname -> begin
       let cmd = Format.sprintf "objdump --dwarf=decodedline %s | grep CU" fname in
       try
-        let in_chan = Unix.open_process_in cmd in
+        let in_chan = Caml_unix.open_process_in cmd in
         In_channel.input_lines in_chan |> List.iter ~f:(fun l ->
                                               let description = sprintf "(Information Exposure Through Debug Information) %s" l in
                                               let cwe_warning = cwe_warning_factory name version description ~symbols:[l] in
@@ -33,7 +33,7 @@ let check_cwe _ project _ _ _ =
 
 
       with
-        Unix.Unix_error (e,fm,argm) ->
-        Log_utils.error (sprintf "[%s] {%s} %s %s %s" name version (Unix.error_message e) fm argm)
+        Caml_unix.Unix_error (e,fm,argm) ->
+        Log_utils.error (sprintf "[%s] {%s} %s %s %s" name version (Caml_unix.error_message e) fm argm)
     end
   | _ -> failwith "[CWE215] symbol_names not as expected"

--- a/src/checkers/cwe_243.ml
+++ b/src/checkers/cwe_243.ml
@@ -40,7 +40,7 @@ let rec check dests (symbols : symbol list) =
       | [] -> true
       | first_symbol :: symbol_rest -> begin
           match first_symbol.address with
-          | Some address -> if address = hd then check tl symbol_rest else check tl symbols
+          | Some address -> if Tid.(=) address hd then check tl symbol_rest else check tl symbols
           | _ -> false
         end
   end
@@ -72,8 +72,8 @@ If all of them fail then we supose that the program handles chroot on
 let check_subfunction prog tid_map sub pathes =
   if sub_calls_symbol prog sub "chroot" then
     begin
-      let path_checks = List.map pathes ~f:(fun path -> check_path prog tid_map sub path) in
-      if not (List.exists path_checks ~f:(fun x -> x = true)) then
+      let path_checks: Bool.t List.t = List.map pathes ~f:(fun path -> check_path prog tid_map sub path) in
+      if not (List.exists path_checks ~f:(fun x -> x)) then
         let address = (Address_translation.translate_tid_to_assembler_address_string (Term.tid sub) tid_map) in
         let tid = Address_translation.tid_to_string @@ Term.tid sub in
         let symbol = Term.name sub in

--- a/src/checkers/cwe_367.ml
+++ b/src/checkers/cwe_367.ml
@@ -12,7 +12,7 @@ let get_calls_to_symbol symbol_name callsites program =
           Seq.filter callsites ~f:(fun callsite -> match Jmp.kind callsite with
             | Goto _ | Ret _ | Int (_,_) -> false
             | Call destination -> match Call.target destination with
-              | Direct addr -> addr = symbol
+              | Direct addr -> Tid.(=) addr symbol
               | _ -> false)
         end
       | None -> Seq.empty
@@ -21,7 +21,7 @@ let get_blk_tid_of_tid sub tid =
  let blk = Seq.find (Term.enum blk_t sub) ~f:(
       fun b ->
       match Term.last jmp_t b with
-      | Some last_term -> tid = (Term.tid last_term)
+      | Some last_term -> Tid.(=) tid (Term.tid last_term)
       | None -> false) in
  match blk with
  | Some b -> Term.tid b

--- a/src/checkers/cwe_457.ml
+++ b/src/checkers/cwe_457.ml
@@ -51,7 +51,7 @@ let get_fp_of_arch arch =
   | _ -> failwith  "Unknown architecture."
 
 let vars_contain_fp vars fp_pointer =
-  let regs = Set.filter vars ~f:(fun var -> Var.to_string var = fp_pointer) in
+  let regs = Set.filter vars ~f:(fun var -> String.(=) (Var.to_string var) fp_pointer) in
   Set.length regs > 0
 
 let is_interesting_load_store def fp_pointer =
@@ -61,7 +61,7 @@ let is_interesting_load_store def fp_pointer =
   contains_mem && contains_fp
 
 (*TODO: implement real filtering*)
-let filter_mem_address i min_fp_offset = Set.filter i ~f:(fun elem -> (Word.of_int  ~width:32 min_fp_offset) < elem)
+let filter_mem_address i min_fp_offset = Set.filter i ~f:(fun elem -> Word.(<) (Word.of_int ~width:32 min_fp_offset) elem)
 
 let log_cwe_warning sub i d tid_map =
    let word = Word.to_string i in
@@ -95,7 +95,7 @@ let check_subfunction _prog proj tid_map sub =
           else
             begin
               let filter_mem_addresses = filter_mem_address ints min_fp_offset in
-              Set.iter filter_mem_addresses ~f:(fun i -> if not (Array.exists !stores ~f:(fun elem -> elem = i)) then
+              Set.iter filter_mem_addresses ~f:(fun i -> if not (Array.exists !stores ~f:(fun elem -> Word.(=) elem i)) then
                 log_cwe_warning sub i d tid_map)
             end
         end)

--- a/src/checkers/cwe_676.ml
+++ b/src/checkers/cwe_676.ml
@@ -12,7 +12,7 @@ let get_call_to_target _cg callee target =
            match Jmp.kind j with
            | Goto _ | Ret _ | Int (_,_) -> None
            | Call dst -> match Call.target dst with
-             | Direct tid when tid = (Term.tid target) ->
+             | Direct tid when Tid.(=) tid (Term.tid target) ->
                Some (Term.name callee, Term.tid j, Term.name target)
              | _ -> None))
 
@@ -48,7 +48,7 @@ let print_calls calls ~tid_map =
 
 let resolve_symbols prog symbols =
   Term.enum sub_t prog |>
-    Seq.filter ~f:(fun s -> List.exists ~f:(fun x -> x = Sub.name s) symbols)
+    Seq.filter ~f:(fun s -> List.exists ~f:(fun x -> String.(=) x (Sub.name s)) symbols)
 
 
 let check_cwe prog _proj tid_map symbol_names _ =

--- a/src/cwe_checker_core.opam
+++ b/src/cwe_checker_core.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "cwe_checker_core"
-version: "0.3"
+version: "0.4"
 synopsis: "Core library for the cwe_checker package"
 description: """
 Core library for the cwe_checker suite of tools.
@@ -12,12 +12,13 @@ homepage: "https://github.com/fkie-cad/cwe_checker"
 bug-reports: "https://github.com/fkie-cad/cwe_checker/issues"
 dev-repo: "git+https://github.com/fkie-cad/cwe_checker"
 depends: [
-  "ocaml" {>= "4.07.1"}
-  "dune" {>= "1.6"}
+  "ocaml" {>= "4.08.0"}
+  "dune" {>= "2.0"}
   "yojson" {>= "1.6.0"}
-  "bap" {>= "2.0"}
-  "core_kernel" {>= "v0.11" & < "v0.12"}
-  "ppx_jane" {>= "v0.11" & < "v0.12"}
+  "bap" {>= "2.2.0"}
+  "alcotest" {>= "0.8.3"}
+  "core_kernel" {>= "v0.14"}
+  "ppx_jane" {>= "v0.14"}
   "ppx_deriving_yojson" {>= "3.5.1"}
   "odoc" {>= "1.4"}
 ]

--- a/src/utils/log_utils.ml
+++ b/src/utils/log_utils.ml
@@ -70,12 +70,12 @@ let get_cwe_warnings () = !cwe_warning_store
 let emit_json target_path out_path =
   let cwe_warning_result = {
       CweCheckerResult.binary = target_path;
-      CweCheckerResult.time = Unix.time ();
+      CweCheckerResult.time = Caml_unix.time ();
       CweCheckerResult.warnings = !cwe_warning_store;
       CweCheckerResult.check_path = !check_path_store
     } in
   let output = Yojson.Safe.pretty_to_string (CweCheckerResult.to_yojson cwe_warning_result) in
-  if out_path = "" then
+  if  String.(=) out_path "" then
     print_endline output
   else
     Out_channel.write_all out_path ~data:output
@@ -86,7 +86,7 @@ let emit_native out_path =
   let output_warnings = List.map !cwe_warning_store ~f:(fun (cwe_warning:CweWarning.t) ->
                             sprintf "[%s] (%s) \n %s" cwe_warning.name cwe_warning.version cwe_warning.description) in
   let output_lines = output_warnings @ output_check_path in
-  if out_path = "" then
+  if String.(=) out_path "" then
     List.iter output_lines ~f:print_endline
   else
     Out_channel.write_lines out_path output_lines

--- a/src/utils/support_functions.ml
+++ b/src/utils/support_functions.ml
@@ -8,11 +8,11 @@ let call_objdump (proj : Project.t) ~flag:(flag : string) ~err:(err : string) : 
   | Some(fname) -> begin
       try
         let cmd = Format.sprintf ("objdump %s %s") flag fname in
-        let in_chan = Unix.open_process_in cmd in
+        let in_chan = Caml_unix.open_process_in cmd in
         let lines = In_channel.input_lines in_chan in
         let () = In_channel.close in_chan in
         lines
       with
-        Unix.Unix_error (e,fm,argm) ->
-          failwith (Format.sprintf "%s %s %s %s" err (Unix.error_message e) fm argm)
+        Caml_unix.Unix_error (e,fm,argm) ->
+          failwith (Format.sprintf "%s %s %s %s" err (Caml_unix.error_message e) fm argm)
     end

--- a/test/unit/analysis/type_inference_test.ml
+++ b/test/unit/analysis/type_inference_test.ml
@@ -34,7 +34,7 @@ let test_update_stack_offset () =
   let def2 = Def.create stack_register (Bil.binop Bil.minus (Bil.var stack_register) (Bil.int (bv 16))) in
   let block = create_block_from_defs [def1; def2] in
   let state = update_block_analysis block fn_start_state ~sub_tid ~project in
-  let () = check "update_stack_offset" ( (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project) = Some(Bitvector.unsigned (bv (-8)))) in
+  let () = check "update_stack_offset" (Poly.(=) (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project) (Some(Bitvector.unsigned (bv (-8))))) in
   ()
 
 let test_preserve_stack_offset_on_stubs () =
@@ -51,10 +51,10 @@ let test_preserve_stack_offset_on_stubs () =
   let block = Blk.Builder.result block in
   let state = update_block_analysis block fn_start_state ~sub_tid ~project in
   let pointer_size = Symbol_utils.arch_pointer_size_in_bytes project in (* since the callee removes the return address from the stack, the stack offset is adjusted accordingly. *)
-  let () = check "preserve_stack_offset_inner_call" ( (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project) = Some(Bitvector.unsigned (bv pointer_size))) in
-  let () = check "delete_stack_info_inner_call" (Mem_region.get state.TypeInfo.stack (bv (-8)) = None) in
+  let () = check "preserve_stack_offset_inner_call" (Poly.(=) (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project) (Some(Bitvector.unsigned (bv pointer_size)))) in
+  let () = check "delete_stack_info_inner_call" (Option.is_none (Mem_region.get state.TypeInfo.stack (bv (-8)))) in
   (* find the malloc extern call. This fails if the example project does not contain a call to malloc. *)
-  let malloc_sub = Seq.find_exn (Term.enum sub_t (Project.program project)) ~f:(fun sub -> Sub.name sub = "malloc") in
+  let malloc_sub = Seq.find_exn (Term.enum sub_t (Project.program project)) ~f:(fun sub -> String.(=) (Sub.name sub) "malloc") in
   let call_term = Jmp.create (Call (Call.create ~target:(Label.direct (Term.tid malloc_sub)) () )) in
   let block = Blk.Builder.create () in
   let () = Blk.Builder.add_def block def1 in
@@ -62,10 +62,10 @@ let test_preserve_stack_offset_on_stubs () =
   let () = Blk.Builder.add_jmp block call_term in
   let block = Blk.Builder.result block in
   let state = update_block_analysis block fn_start_state ~sub_tid ~project in
-  let () = check "preserve_stack_offset_extern_malloc_call" ( (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project) = Some(Bitvector.unsigned (bv pointer_size))) in
-  let () = check "preserve_stack_info_extern_malloc_call" (Mem_region.get state.TypeInfo.stack (bv (-8)) = Some(Ok((Data, bv 8)))) in
+  let () = check "preserve_stack_offset_extern_malloc_call" (Poly.(=) (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project) (Some(Bitvector.unsigned (bv pointer_size)))) in
+  let () = check "preserve_stack_info_extern_malloc_call" (Poly.(=) (Mem_region.get state.TypeInfo.stack (bv (-8))) (Some(Ok((Data, bv 8))))) in
   (* find the "free" extern call. This fails if the example project does not contain a call to "free". *)
-  let extern_sub = Seq.find_exn (Term.enum sub_t (Project.program project)) ~f:(fun sub -> Sub.name sub = "free") in
+  let extern_sub = Seq.find_exn (Term.enum sub_t (Project.program project)) ~f:(fun sub -> String.(=) (Sub.name sub) "free") in
   let call_term = Jmp.create (Call (Call.create ~target:(Label.direct (Term.tid extern_sub)) () )) in
   let block = Blk.Builder.create () in
   let () = Blk.Builder.add_def block def1 in
@@ -73,8 +73,8 @@ let test_preserve_stack_offset_on_stubs () =
   let () = Blk.Builder.add_jmp block call_term in
   let block = Blk.Builder.result block in
   let state = update_block_analysis block fn_start_state ~sub_tid ~project in
-  let () = check "preserve_stack_offset_extern_call" ( (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project) = Some(Bitvector.unsigned (bv pointer_size))) in
-  let () = check "delete_stack_info_extern_call" (Mem_region.get state.TypeInfo.stack (bv (-8)) <> Some(Ok((Data, bv 8)))) in
+  let () = check "preserve_stack_offset_extern_call" (Poly.(=) (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project) (Some(Bitvector.unsigned (bv pointer_size)))) in
+  let () = check "delete_stack_info_extern_call" (Poly.(<>) (Mem_region.get state.TypeInfo.stack (bv (-8))) (Some(Ok((Data, bv 8))))) in
   ()
 
 let test_update_reg () =
@@ -90,7 +90,7 @@ let test_update_reg () =
     | Some(Ok(Pointer(_))) -> true
     |_ -> false
   ) in
-  let () = check "update_data_register" (Var.Map.find state.TypeInfo.reg register2 = Some(Ok(Data))) in
+  let () = check "update_data_register" (Poly.(=) (Var.Map.find state.TypeInfo.reg register2) (Some(Ok(Data)))) in
   let def1 = Def.create register1 (Bil.Load (Bil.var register1, Bil.var register2, Bitvector.LittleEndian, `r64) ) in
   let block = create_block_from_defs [def1;] in
   let state = update_block_analysis block fn_start_state ~sub_tid ~project in
@@ -113,7 +113,7 @@ let test_update_stack () =
   let state = update_block_analysis block fn_start_state ~sub_tid ~project in
   let () = check "write_to_stack" (
     match Mem_region.get state.TypeInfo.stack (bv (-8)) with
-    | Some(Ok(Pointer(_targets), size )) when size = bv (Symbol_utils.arch_pointer_size_in_bytes project) -> true
+    | Some(Ok(Pointer(_targets), size )) when Poly.(=) size (bv (Symbol_utils.arch_pointer_size_in_bytes project)) -> true
     | _ -> false
   ) in
   let () = check "load_from_stack" (
@@ -138,7 +138,7 @@ let test_address_registers_on_load_and_store () =
     | Ok(Pointer(targets)) -> (Map.is_empty targets)
     | _ -> false
   ) in
-  let () = check "dont_change_offsets_on_address_register" (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project = Some(bv 0)) in
+  let () = check "dont_change_offsets_on_address_register" (Poly.(=) (compute_stack_offset state (Bil.var stack_register) ~sub_tid ~project) (Some(bv 0))) in
   ()
 
 let test_merge_type_infos () =
@@ -149,25 +149,25 @@ let test_merge_type_infos () =
   let state1 = update_block_analysis block fn_start_state ~sub_tid ~project in
   let state2 = update_block_analysis block generic_empty_state ~sub_tid ~project in
   let merged_state = merge_type_infos state1 state1 in
-  let () = check "merge_same_stack_offset" (compute_stack_offset merged_state (Bil.var stack_register) ~sub_tid ~project = Some(Bitvector.unsigned (bv 8))) in
+  let () = check "merge_same_stack_offset" (Poly.(=) (compute_stack_offset merged_state (Bil.var stack_register) ~sub_tid ~project) (Some(Bitvector.unsigned (bv 8)))) in
   let merged_state = merge_type_infos fn_start_state state1 in
-  let () = check "merge_different_stack_offsets" (compute_stack_offset merged_state (Bil.var stack_register) ~sub_tid ~project = None) in
+  let () = check "merge_different_stack_offsets" (Option.is_none (compute_stack_offset merged_state (Bil.var stack_register) ~sub_tid ~project)) in
   let merged_state = merge_type_infos generic_empty_state state1 in
-  let () = check "merge_with_unknown_stack_offset" (compute_stack_offset merged_state (Bil.var stack_register) ~sub_tid ~project = Some(Bitvector.unsigned (bv 8))) in
+  let () = check "merge_with_unknown_stack_offset" (Poly.(=) (compute_stack_offset merged_state (Bil.var stack_register) ~sub_tid ~project) (Some(Bitvector.unsigned (bv 8)))) in
   let merged_state = merge_type_infos generic_empty_state state2 in
-  let () = check "merge_empty_stack_offsets" (compute_stack_offset merged_state (Bil.var stack_register) ~sub_tid ~project = None) in
+  let () = check "merge_empty_stack_offsets" (Option.is_none (compute_stack_offset merged_state (Bil.var stack_register) ~sub_tid ~project)) in
   ()
 
 let test_type_info_equal () =
   let (project, _stack_register, _sub, sub_tid, fn_start_state) = test_preamble () in
   let generic_empty_state = only_stack_pointer_and_flags sub_tid project in
-  let () = check "empty_state_neq_fn_start_state" (false = (type_info_equal fn_start_state generic_empty_state)) in
+  let () = check "empty_state_neq_fn_start_state" (Bool.(=) false (type_info_equal fn_start_state generic_empty_state)) in
   ()
 
 let test_malloc_call_return_reg () =
   let (project, _stack_register, _sub, sub_tid, fn_start_state) = test_preamble () in
   (* find the malloc extern call. This fails if the example project does not contain a call to malloc. *)
-  let malloc_sub = Seq.find_exn (Term.enum sub_t (Project.program project)) ~f:(fun sub -> Sub.name sub = "malloc") in
+  let malloc_sub = Seq.find_exn (Term.enum sub_t (Project.program project)) ~f:(fun sub -> String.(=) (Sub.name sub) "malloc") in
   let call_term = Jmp.create (Call (Call.create ~target:(Label.direct (Term.tid malloc_sub)) () )) in
   let block = Blk.Builder.create () in
   let () = Blk.Builder.add_jmp block call_term in
@@ -176,12 +176,12 @@ let test_malloc_call_return_reg () =
   (* test whether the return register is marked as a pointer register. This fails if the example project is not a x64 binary. *)
   let state_reg_list = Map.to_alist state.TypeInfo.reg in
   let () = String.Set.iter (Symbol_utils.parse_dyn_syms project) ~f:(fun elem -> print_endline elem) in
-  let () = check "malloc_return_register_marked" (match List.find state_reg_list ~f:(fun (var, _register_info) -> Var.name var = "RAX") with
+  let () = check "malloc_return_register_marked" (match List.find state_reg_list ~f:(fun (var, _register_info) -> String.(=) (Var.name var) "RAX") with
     | Some((_var, register_info)) ->  (* TODO: test whether the target is set correctly. *)
         begin match register_info with
         | Ok(Pointer(targets)) ->
             begin match Map.to_alist targets with
-            | (target_tid, _) :: [] -> target_tid = Term.tid call_term
+            | (target_tid, _) :: [] -> Tid.(=) target_tid (Term.tid call_term)
             | _ -> false
             end
         | _ -> false

--- a/test/unit/checkers/cwe_476_test.ml
+++ b/test/unit/checkers/cwe_476_test.ml
@@ -19,7 +19,7 @@ let call_handling_test () =
 
   let state = State.set_register state rax_register mock_taint in
   let _state = flag_unchecked_return_values state ~cwe_hits:mock_hits ~project in
-  check "flag_RAX_return" (false = Taint.is_empty !mock_hits);
+  check "flag_RAX_return" (Bool.(=) false (Taint.is_empty !mock_hits));
   let state = State.empty in
   let state = State.set_register state rbx_register mock_taint in
   mock_hits := Taint.empty;
@@ -30,7 +30,7 @@ let call_handling_test () =
   mock_hits := Taint.empty;
   let state = State.set_register state rbx_register mock_taint in
   let _state = flag_register_taints state ~cwe_hits:mock_hits in
-  check "flag_all_registers" (false = Taint.is_empty !mock_hits);
+  check "flag_all_registers" (Bool.(=) false (Taint.is_empty !mock_hits));
 
   let state = State.empty in
   mock_hits := Taint.empty;
@@ -38,7 +38,7 @@ let call_handling_test () =
   let state = State.set_register state rdx_register mock_taint in
   let state = State.set_register state rbx_register other_mock_taint in
   let state = flag_parameter_register state ~cwe_hits:mock_hits ~project in
-  check "flag_RDX_parameter" (false = Taint.is_empty !mock_hits && Option.is_none (State.find_register state rdx_register));
+  check "flag_RDX_parameter" (Bool.(=) false (Taint.is_empty !mock_hits) && Option.is_none (State.find_register state rdx_register));
   check "dont_flag_RBX_parameter" (Option.is_some (State.find_register state rbx_register));
 
   let state = State.empty in

--- a/test/unit/checkers/cwe_560_test.ml
+++ b/test/unit/checkers/cwe_560_test.ml
@@ -5,11 +5,11 @@ let check msg x = Alcotest.(check bool) msg true x
 
 let test_is_chmod_style_arg_with_umask_arg () : unit =
   let res = Cwe_560.Private.is_chmod_style_arg 022 in
-  check "empty" (res = false)
+  check "empty" (Bool.(=) res false)
 
 let test_is_chmod_style_arg_with_chmod_arg () : unit =
   let res = Cwe_560.Private.is_chmod_style_arg 666 in
-  check "empty" (res = true)
+  check "empty" (Bool.(=) res true)
 
 let tests = [
   "Is chmod style argument with umask argument?", `Quick, test_is_chmod_style_arg_with_umask_arg;

--- a/test/unit/unit_tests_cwe_checker.ml
+++ b/test/unit/unit_tests_cwe_checker.ml
@@ -108,7 +108,7 @@ let generate_bap_params params =
 let () =
   (* Check whether this file is run as an executable (via dune runtest) or
      as a bap plugin *)
-  if Sys.argv.(0) = "bap" then
+  if String.(=) Sys.argv.(0) "bap" then
     let cmdline_params = generate_bap_params cmdline_params in
     let () = Config.when_ready (fun ({get=(!!)}) ->
       let params: String.t String.Map.t = List.fold cmdline_params ~init:String.Map.empty ~f:(fun param_map (name, bap_param) ->

--- a/test/unit/utils/address_translation_test.ml
+++ b/test/unit/utils/address_translation_test.ml
@@ -13,8 +13,8 @@ let test_translate_tid_to_assembler_address_string () =
   let tid_1 = Tid.create () in
   let tid_2 = Tid.create () in
   let tid_map = Map.add_exn tid_map ~key:tid_1 ~data:(Addr.of_bool true) in
-  let () = check "TID not correctly mapped to address" (translate_tid_to_assembler_address_string tid_1 tid_map = "1:1u") in
-  let () = check "TID not correctly mapped to address" (translate_tid_to_assembler_address_string tid_2 tid_map = "UNKNOWN") in
+  let () = check "TID not correctly mapped to address" (String.(=) (translate_tid_to_assembler_address_string tid_1 tid_map) "1:1u") in
+  let () = check "TID not correctly mapped to address" (String.(=) (translate_tid_to_assembler_address_string tid_2 tid_map) "UNKNOWN") in
   ()
 
 
@@ -35,8 +35,8 @@ let test_generate_tid_map () =
   let program = Term.append sub_t program s in
   let tid_map = generate_tid_map program in
 
-  let () = check "address not in vicinity" (translate_tid_to_assembler_address_string (Term.tid s) tid_map = "UNKNOWN") in
-  let () = check "address not in vicinity" (translate_tid_to_assembler_address_string (Term.tid d_1) tid_map = "1:1u") in
+  let () = check "address not in vicinity" (String.(=) (translate_tid_to_assembler_address_string (Term.tid s) tid_map) "UNKNOWN") in
+  let () = check "address not in vicinity" (String.(=) (translate_tid_to_assembler_address_string (Term.tid d_1) tid_map) "1:1u") in
   ()
 
 

--- a/test/unit/utils/cconv_test.ml
+++ b/test/unit/utils/cconv_test.ml
@@ -26,7 +26,7 @@ let test_callee_saved () =
       let register = Var.create "EBX" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
       let () = check "callee_saved_register" (is_callee_saved register project) in
       let register = Var.create "EAX" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-      let () = check "caller_saved_register" (is_callee_saved register project = false) in
+      let () = check "caller_saved_register" (Bool.(=) (is_callee_saved register project) false) in
       ()
   end
   | "" -> begin
@@ -37,14 +37,14 @@ let test_callee_saved () =
             let register = Var.create "RDI" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
             let () = check "callee_saved_register" (is_callee_saved register project) in
             let register = Var.create "R8" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-            let () = check "caller_saved_register" (is_callee_saved register project = false) in
+            let () = check "caller_saved_register" (Bool.(=) (is_callee_saved register project) false) in
             ()
         end
         | "elf" -> begin
             let register = Var.create "RBX" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
             let () = check "callee_saved_register" (is_callee_saved register project) in
             let register = Var.create "RDI" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-            let () = check "caller_saved_register" (is_callee_saved register project = false) in
+            let () = check "caller_saved_register" (Bool.(=) (is_callee_saved register project) false) in
             ()
         end
         | _ -> failwith "Not a valid binary format"
@@ -53,7 +53,7 @@ let test_callee_saved () =
         let register = Var.create "S0" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "callee_saved_register" (is_callee_saved register project) in
         let register = Var.create "A0" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "callee_saved_register" (is_callee_saved register project = false) in
+        let () = check "callee_saved_register" (Bool.(=) (is_callee_saved register project) false) in
         ()
     end
     | "armv4" | "armv5" | "armv6" | "armv7" | "armv4eb" | "armv5eb"
@@ -62,28 +62,28 @@ let test_callee_saved () =
         let register = Var.create "R4" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "callee_saved_register" (is_callee_saved register project) in
         let register = Var.create "R0" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "callee_saved_register" (is_callee_saved register project = false) in
+        let () = check "callee_saved_register" (Bool.(=) (is_callee_saved register project) false) in
         ()
     end
     | "aarch64" -> begin
         let register = Var.create "X18" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "callee_saved_register" (is_callee_saved register project) in
         let register = Var.create "X0" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "callee_saved_register" (is_callee_saved register project = false) in
+        let () = check "callee_saved_register" (Bool.(=) (is_callee_saved register project) false) in
         ()
     end
     | "powerpc" -> begin
         let register = Var.create "R14" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "callee_saved_register" (is_callee_saved register project) in
         let register = Var.create "R4" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "callee_saved_register" (is_callee_saved register project = false) in
+        let () = check "callee_saved_register" (Bool.(=) (is_callee_saved register project) false) in
         ()
     end
     | "powerpc64" | "powerpc64le" -> begin
         let register = Var.create "R14" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "callee_saved_register" (is_callee_saved register project) in
         let register = Var.create "R10" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "callee_saved_register" (is_callee_saved register project = false) in
+        let () = check "callee_saved_register" (Bool.(=) (is_callee_saved register project) false) in
         ()
     end
     | _ -> failwith "Not a supported architecture"
@@ -100,9 +100,9 @@ let test_parameter_register () =
   match cconv with
   | "cdecl" | "stdcall" | "ms" -> begin
       let register = Var.create "EBX" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-      let () = check "parameter_register" (is_parameter_register register project = false) in
+      let () = check "parameter_register" (Bool.(=) (is_parameter_register register project) false) in
       let register = Var.create "EAX" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-      let () = check "parameter_register" (is_parameter_register register project = false) in
+      let () = check "parameter_register" (Bool.(=) (is_parameter_register register project) false) in
       ()
     end
   | "fastcall" -> begin
@@ -120,14 +120,14 @@ let test_parameter_register () =
             let register = Var.create "R8" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
             let () = check "parameter_register" (is_parameter_register register project) in
             let register = Var.create "RDI" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-            let () = check "parameter_register" (is_parameter_register register project = false) in
+            let () = check "parameter_register" (Bool.(=) (is_parameter_register register project) false) in
             ()
         end
         | "elf" -> begin
             let register = Var.create "RDI" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
             let () = check "parameter_register" (is_parameter_register register project) in
             let register = Var.create "RBP" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-            let () = check "parameter_register" (is_parameter_register register project = false) in
+            let () = check "parameter_register" (Bool.(=) (is_parameter_register register project) false) in
             ()
         end
         | _ -> failwith "Not a valid binary format"
@@ -136,14 +136,14 @@ let test_parameter_register () =
         let register = Var.create "A3" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "parameter_register" (is_parameter_register register project) in
         let register = Var.create "V0" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "parameter_register" (is_parameter_register register project = false) in
+        let () = check "parameter_register" (Bool.(=) (is_parameter_register register project) false) in
         ()
     end
     | "aarch64" -> begin
         let register = Var.create "X2" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "parameter_register" (is_parameter_register register project) in
         let register = Var.create "X23" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "parameter_register" (is_parameter_register register project = false) in
+        let () = check "parameter_register" (Bool.(=) (is_parameter_register register project) false) in
         ()
     end
     | "armv4" | "armv5" | "armv6" | "armv7" | "armv4eb" | "armv5eb"
@@ -152,21 +152,21 @@ let test_parameter_register () =
         let register = Var.create "R3" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "parameter_register" (is_parameter_register register project) in
         let register = Var.create "LR" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "parameter_register" (is_parameter_register register project = false) in
+        let () = check "parameter_register" (Bool.(=) (is_parameter_register register project) false) in
         ()
     end
     | "powerpc" -> begin
         let register = Var.create "R3" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "parameter_register" (is_parameter_register register project) in
         let register = Var.create "F1" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "parameter_register" (is_parameter_register register project = false) in
+        let () = check "parameter_register" (Bool.(=) (is_parameter_register register project) false) in
         ()
     end
     | "powerpc64" | "powerpc64le" -> begin
         let register = Var.create "R3" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "parameter_register" (is_parameter_register register project) in
         let register = Var.create "R31" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "parameter_register" (is_parameter_register register project = false) in
+        let () = check "parameter_register" (Bool.(=) (is_parameter_register register project) false) in
         ()
     end
     | _ -> failwith "Not a supported architecture"
@@ -185,7 +185,7 @@ let test_return_register () =
       let register = Var.create "EDX" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
       let () = check "return_register" (is_return_register register project) in
       let register = Var.create "EBP" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-      let () = check "no_return_register" (is_return_register register project = false) in
+      let () = check "no_return_register" (Bool.(=) (is_return_register register project) false) in
       ()
   end
   | "" -> begin
@@ -196,14 +196,14 @@ let test_return_register () =
             let register = Var.create "RAX" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
             let () = check "return_register" (is_return_register register project) in
             let register = Var.create "RDX" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-            let () = check "no_return_register" (is_return_register register project = false) in
+            let () = check "no_return_register" (Bool.(=) (is_return_register register project) false) in
             ()
         end
         | "elf" -> begin
             let register = Var.create "RDX" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
             let () = check "return_register" (is_return_register register project) in
             let register = Var.create "R12" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-            let () = check "no_return_register" (is_return_register register project = false) in
+            let () = check "no_return_register" (Bool.(=) (is_return_register register project) false) in
             ()
         end
         | _ -> failwith "Not a valid binary format"
@@ -212,14 +212,14 @@ let test_return_register () =
         let register = Var.create "V0" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "return_register" (is_return_register register project) in
         let register = Var.create "A0" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "no_return_register" (is_return_register register project = false) in
+        let () = check "no_return_register" (Bool.(=) (is_return_register register project) false) in
         ()
     end
     | "aarch64" -> begin
         let register = Var.create "X1" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "return_register" (is_return_register register project) in
         let register = Var.create "X30" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "no_return_register" (is_return_register register project = false) in
+        let () = check "no_return_register" (Bool.(=) (is_return_register register project) false) in
         ()
     end
     | "armv4" | "armv5" | "armv6" | "armv7" | "armv4eb" | "armv5eb"
@@ -228,21 +228,21 @@ let test_return_register () =
         let register = Var.create "R3" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "return_register" (is_return_register register project) in
         let register = Var.create "R4" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "no_return_register" (is_return_register register project = false) in
+        let () = check "no_return_register" (Bool.(=) (is_return_register register project) false) in
         ()
     end
     | "powerpc" -> begin
         let register = Var.create "R3" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "return_register" (is_return_register register project) in
         let register = Var.create "R10" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "no_return_register" (is_return_register register project = false) in
+        let () = check "no_return_register" (Bool.(=) (is_return_register register project) false) in
         ()
     end
     | "powerpc64" | "powerpc64le" -> begin
         let register = Var.create "R3" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
         let () = check "return_register" (is_return_register register project) in
         let register = Var.create "R25" (Bil.Imm (Symbol_utils.arch_pointer_size_in_bytes project * 8)) in
-        let () = check "no_return_register" (is_return_register register project = false) in
+        let () = check "no_return_register" (Bool.(=) (is_return_register register project) false) in
         ()
     end
     | _ -> failwith "Not a supported architecture"
@@ -252,7 +252,7 @@ let test_return_register () =
 
 let test_extract_bin_format () =
   let project = Option.value_exn !example_project in
-  let () = check "bin_format" (extract_bin_format project = (Option.value_exn !example_bin_format)) in
+  let () = check "bin_format" (Poly.(=) (extract_bin_format project) (Option.value_exn !example_bin_format)) in
   ()
 
 

--- a/test/unit/utils/parse_dyn_syms_test.ml
+++ b/test/unit/utils/parse_dyn_syms_test.ml
@@ -14,7 +14,7 @@ let test_parse_dyn_syms () =
   let () = check "free_as_dyn_sym" (String.Set.mem (parse_dyn_syms project) "free") in
   let () = check "__libc_start_main_as_dyn_sym" (String.Set.mem (parse_dyn_syms project) "__libc_start_main") in
   let () = check "malloc_as_dyn_sym" (String.Set.mem (parse_dyn_syms project) "malloc") in
-  let () = check "realloc_not_a_dyn_sym" (false = String.Set.mem (parse_dyn_syms project) "realloc") in
+  let () = check "realloc_not_a_dyn_sym" (Bool.(=) false (String.Set.mem (parse_dyn_syms project) "realloc")) in
   ()
 
 

--- a/test/unit/utils/serde_json_test.ml
+++ b/test/unit/utils/serde_json_test.ml
@@ -11,66 +11,66 @@ let test_serde () =
   let serde = build_null () in
   let json = to_string serde in
   print_endline json;
-  check "serde_null" (json = "null");
+  check "serde_null" (String.(=) json "null");
   let serde = build_bool true in
   let json = to_string serde in
   print_endline json;
-  check "serde_bool" (json = "true");
+  check "serde_bool" (String.(=) json "true");
   let serde = build_number 45 in
   let json = to_string serde in
   print_endline json;
-  check "serde_number" (json = "45");
+  check "serde_number" (String.(=) json "45");
   let serde = build_string "hello" in
   let json = to_string serde in
   print_endline json;
-  check "serde_string" (json = "\"hello\"");
+  check "serde_string" (String.(=) json "\"hello\"");
   let serde = build_array [build_number 23; build_bool false] in
   let json = to_string serde in
   print_endline json;
-  check "serde_array" (json = "[23,false]");
+  check "serde_array" (String.(=) json "[23,false]");
   let serde = build_object [("hello", build_number 23); ("world", build_bool false)] in
   let json = to_string serde in
   print_endline json;
-  check "serde_object" (json = "{\"hello\":23,\"world\":false}")
+  check "serde_object" (String.(=) json "{\"hello\":23,\"world\":false}")
 
 let test_type_conversions () =
   let var_type = Bil.Types.Mem (`r64, `r8) in
   let serde = Serde_json.of_var_type var_type in
   let json = Serde_json.to_string serde in
   print_endline json;
-  check "Var_Type" (json = "{\"Memory\":{\"addr_size\":64,\"elem_size\":8}}");
+  check "Var_Type" (String.(=) json "{\"Memory\":{\"addr_size\":64,\"elem_size\":8}}");
   let var = Var.create "RAX" var_type in
   let serde = Serde_json.of_var var in
   let json = Serde_json.to_string serde in
   print_endline json;
-  check "Var" (json = "{\"is_temp\":false,\"name\":\"RAX\",\"type_\":{\"Memory\":{\"addr_size\":64,\"elem_size\":8}}}");
+  check "Var" (String.(=) json "{\"is_temp\":false,\"name\":\"RAX\",\"type_\":{\"Memory\":{\"addr_size\":64,\"elem_size\":8}}}");
   let cast_type = Bil.Types.UNSIGNED in
   let serde = Serde_json.of_cast_type cast_type in
   let json = Serde_json.to_string serde in
   print_endline json;
-  check "Cast_Type" (json = "\"UNSIGNED\"");
+  check "Cast_Type" (String.(=) json "\"UNSIGNED\"");
   let unop = Bil.Types.NEG in
   let serde = Serde_json.of_unop_type unop in
   let json = Serde_json.to_string serde in
   print_endline json;
-  check "Unop_Type" (json = "\"NEG\"");
+  check "Unop_Type" (String.(=) json "\"NEG\"");
   let bitv = Bitvector.of_int ~width:8 234 in
   let serde = Serde_json.of_bitvector bitv in
   let json = Serde_json.to_string serde in
   print_endline json;
-  check "Bitvector" (json = "{\"digits\":[234],\"width\":[8]}");
+  check "Bitvector" (String.(=) json "{\"digits\":[234],\"width\":[8]}");
   let exp = Bil.binop Bil.PLUS (Bil.int bitv) (Bil.int bitv) in
   let serde = Serde_json.of_exp exp in
   let json = Serde_json.to_string serde in
   print_endline json;
-  check "Expression" (json = "{\"BinOp\":{\"lhs\":{\"Const\":{\"digits\":[234],\"width\":[8]}},\"op\":\"PLUS\",\"rhs\":{\"Const\":{\"digits\":[234],\"width\":[8]}}}}");
+  check "Expression" (String.(=) json "{\"BinOp\":{\"lhs\":{\"Const\":{\"digits\":[234],\"width\":[8]}},\"op\":\"PLUS\",\"rhs\":{\"Const\":{\"digits\":[234],\"width\":[8]}}}}");
   let tid = Tid.for_name "block" in
   let term = Blk.create ~tid () in
   let tid_map = Tid.Map.empty in
   let serde = Serde_json.of_blk term tid_map in
   let json = Serde_json.to_string serde in
   print_endline json;
-  check "Block_term" (json = "{\"term\":{\"defs\":[],\"jmps\":[]},\"tid\":{\"address\":\"UNKNOWN\",\"id\":\"@block\"}}";)
+  check "Block_term" (String.(=) json "{\"term\":{\"defs\":[],\"jmps\":[]},\"tid\":{\"address\":\"UNKNOWN\",\"id\":\"@block\"}}";)
 
 let test_project_conversion () =
   let project = Option.value_exn !example_project in

--- a/test/unit/utils/symbol_utils_test.ml
+++ b/test/unit/utils/symbol_utils_test.ml
@@ -13,7 +13,7 @@ let test_check_if_symbols_resolved () =
   let project = Option.value_exn !example_project in
   let program = Project.program project in
   let tid_address_map = Address_translation.generate_tid_map program in
-  let () = check "no_symbols" (check_if_symbols_resolved project program tid_address_map = false) in
+  let () = check "no_symbols" (Bool.(=) (check_if_symbols_resolved project program tid_address_map) false) in
   ()
 
 


### PR DESCRIPTION
This PR updates the Ocaml source files to support Ocaml 4.08 and BAP 2.2. The version number was also changed to 0.4, since this is probably the last PR before officially releasing version 0.4.