### PR TITLE
Cargo test action

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -14,12 +14,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install cross compilers
         run: ./test/artificial_samples/install_cross_compilers.sh
-      - name: Install Scons and curl
-        run: |
-          sudo apt-get install python-pip curl -y
-          pip install scons
       - name: Compile artificial samples
         run: |
+          pip install scons
           cd test/artificial_samples
           scons
       - uses: actions/setup-java@v1

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -12,17 +12,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install cross compilers
-        run: ./test/artificial_samples/install_cross_compilers.sh
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '2.7'
-      - name: Compile artificial samples
+      - name: Build and run docker image for cross compiling
         run: |
-          pip install --upgrade pip
-          pip install scons
           cd test/artificial_samples
-          scons
+          docker build -t cross_compiling .
+          docker run --rm -v $(pwd)/build:/home/cwe/artificial_samples/build cross_compiling sudo /home/cwe/.local/bin/scons
       - uses: actions/setup-java@v1
         with:
           java-version: "11.0.x"

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,6 +1,6 @@
 name: Acceptance tests
 
-on: push
+on: [pull_request]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install cross compilers
         run: ./test/artificial_samples/install_cross_compilers.sh
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
       - name: Compile artificial samples
         run: |
           pip install scons

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -16,7 +16,7 @@ jobs:
         run: ./test/artificial_samples/install_cross_compilers.sh
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.6'
       - name: Compile artificial samples
         run: |
           pip install scons

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -1,0 +1,46 @@
+name: Acceptance tests
+
+on: push
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs: 
+ 
+  acceptance-tests:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install cross compilers
+        run: ./test/artificial_samples/install_cross_compilers.sh
+      - name: Install Scons and curl
+        run: |
+          sudo apt-get install python-pip curl -y
+          pip install scons
+      - name: Compile artificial samples
+        run: |
+          cd test/artificial_samples
+          scons
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "11.0.x"
+          java-package: jdk
+          architecture: x64
+      - name: Install Ghidra
+        run: |
+          curl -fSL https://www.ghidra-sre.org/ghidra_9.2.1_PUBLIC_20201215.zip -o ghidra.zip
+          unzip -q ghidra.zip
+          mv ghidra_9.2.1_PUBLIC /opt/ghidra
+          rm ghidra.zip
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install cwe_checker
+        run: make all GHIDRA_PATH=/opt/ghidra
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --no-fail-fast -p acceptance_tests_ghidra -- --show-output --ignored --test-threads 1

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -16,9 +16,10 @@ jobs:
         run: ./test/artificial_samples/install_cross_compilers.sh
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: '2.7'
       - name: Compile artificial samples
         run: |
+          pip install --upgrade pip
           pip install scons
           cd test/artificial_samples
           scons

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,21 @@
+name: Unit tests
+
+on: [push]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ else
 	cargo test --no-fail-fast -p acceptance_tests_ghidra -- --show-output --ignored
 endif
 
+compile_test_files:
+	cd test/artificial_samples \
+	&& docker build -t cross_compiling . \
+	&& docker run --rm -v $(pwd)/build:/home/cwe/artificial_samples/build cross_compiling sudo /home/cwe/.local/bin/scons
+
 codestyle-check:
 	cargo fmt -- --check
 	cargo clippy -- -D clippy::all

--- a/cwe_checker_rs/src/checkers/cwe_243.rs
+++ b/cwe_checker_rs/src/checkers/cwe_243.rs
@@ -143,8 +143,12 @@ pub fn check_cwe(
                 if let Some(chdir_tid) =
                     find_symbol(&project.program, "chdir").map(|(tid, _)| tid.clone())
                 {
+                    if graph.neighbors(node).count() > 1 {
+                        panic!("Malformed Control flow graph: More than one edge for extern function call")
+                    }
+                    let chroot_return_to_node = graph.neighbors(node).next().unwrap();
                     // If chdir is called after chroot, we assume a secure chroot jail.
-                    if is_sink_call_reachable_from_source_call(graph, node, &chroot_tid, &chdir_tid)
+                    if is_sink_call_reachable_from_source_call(graph, chroot_return_to_node, &chroot_tid, &chdir_tid)
                         .is_none()
                     {
                         // If chdir is not called after chroot, it has to be called before it.

--- a/test/artificial_samples/Dockerfile
+++ b/test/artificial_samples/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get -y update \
     && apt-get install -y sudo \
     && useradd -m cwe \
     && echo "cwe:cwe" | chpasswd \
-    && adduser bap sudo \
+    && adduser cwe sudo \
     && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
     
 USER cwe

--- a/test/artificial_samples/Dockerfile
+++ b/test/artificial_samples/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:xenial
+
+RUN apt-get -y update \
+    && apt-get install -y sudo \
+    && useradd -m cwe \
+    && echo "cwe:cwe" | chpasswd \
+    && adduser bap sudo \
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+    
+USER cwe
+
+RUN sudo apt-get install python-pip apt-utils -y
+
+RUN pip install --upgrade pip
+
+RUN pip install scons
+
+ENV PATH="/home/cwe/.local/bin/:${PATH}"
+
+COPY . /home/cwe/artificial_samples/
+
+WORKDIR /home/cwe/artificial_samples/
+
+RUN ./install_cross_compilers.sh
+
+# RUN sudo /home/cwe/.local/bin/scons

--- a/test/artificial_samples/Readme.md
+++ b/test/artificial_samples/Readme.md
@@ -1,0 +1,18 @@
+# Test binaries for the acceptance test suite
+
+For the acceptance test suite of the *cwe_checker*,
+the C-files inside this directory have to be compiled for a variety of CPU architectures and C-compilers.
+The provided dockerfile should be used for the build process.
+
+## Prerequisites
+
+- Have Docker installed on your system
+
+## Build commands
+
+Inside this directory run the following commands:
+```shell
+docker build -t cross_compiling .
+docker run --rm -v $(pwd)/build:/home/cwe/artificial_samples/build cross_compiling sudo /home/cwe/.local/bin/scons
+```
+


### PR DESCRIPTION
This PR adds Github actions for running unit tests and acceptance tests.

The acceptance tests are running way too slow right now, thus they only run on pull requests right now. Part of the reason is that we cannot run them in parallel without triggering random test failures. Execution of Ghidra for very small input files is also way too slow at the moment, but this is a problem for another PR.

Edit: The PR now also contains a bugfix for the CWE 243 check uncovered by the acceptance tests.