### PR TITLE
Add address_base_offset field to Program struct

### DIFF
--- a/cwe_checker_rs/src/analysis/backward_interprocedural_fixpoint/tests.rs
+++ b/cwe_checker_rs/src/analysis/backward_interprocedural_fixpoint/tests.rs
@@ -126,6 +126,7 @@ fn mock_program() -> Term<Program> {
             subs: vec![sub1, sub2],
             extern_symbols: Vec::new(),
             entry_points: Vec::new(),
+            address_base_offset: 0,
         },
     };
     program

--- a/cwe_checker_rs/src/analysis/graph.rs
+++ b/cwe_checker_rs/src/analysis/graph.rs
@@ -500,6 +500,7 @@ mod tests {
                 subs: vec![sub1, sub2],
                 extern_symbols: Vec::new(),
                 entry_points: Vec::new(),
+                address_base_offset: 0,
             },
         };
         program

--- a/cwe_checker_rs/src/analysis/pointer_inference/context/tests.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/context/tests.rs
@@ -76,6 +76,7 @@ fn mock_project() -> (Project, Config) {
             mock_extern_symbol("other"),
         ],
         entry_points: Vec::new(),
+        address_base_offset: 0,
     };
     let program_term = Term {
         tid: Tid::new("program"),

--- a/cwe_checker_rs/src/intermediate_representation/term.rs
+++ b/cwe_checker_rs/src/intermediate_representation/term.rs
@@ -307,6 +307,14 @@ pub struct Program {
     /// Entry points into to binary,
     /// i.e. the term identifiers of functions that may be called from outside of the binary.
     pub entry_points: Vec<Tid>,
+    /// An offset that has been added to all addresses in the program compared to the addresses
+    /// as specified in the binary file.
+    ///
+    /// In certain cases, e.g. if the binary specifies a segment to be loaded at address 0,
+    /// the Ghidra backend may shift the whole binary image by a constant value in memory.
+    /// Thus addresses as specified by the binary and addresses as reported by Ghidra may differ by a constant offset,
+    /// which is stored in this value.
+    pub address_base_offset: u64,
 }
 
 impl Program {
@@ -503,6 +511,7 @@ mod tests {
                 subs: Vec::new(),
                 extern_symbols: Vec::new(),
                 entry_points: Vec::new(),
+                address_base_offset: 0,
             }
         }
     }

--- a/cwe_checker_rs/src/pcode/term.rs
+++ b/cwe_checker_rs/src/pcode/term.rs
@@ -354,12 +354,19 @@ pub struct Program {
     pub subs: Vec<Term<Sub>>,
     pub extern_symbols: Vec<ExternSymbol>,
     pub entry_points: Vec<Tid>,
+    pub image_base: String,
 }
 
-impl From<Program> for IrProgram {
+impl Program {
     /// Convert a program parsed from Ghidra to the internally used IR.
-    fn from(program: Program) -> IrProgram {
-        let subs = program
+    ///
+    /// The `binary_base_address` denotes the base address of the memory image of the binary
+    /// according to the program headers of the binary.
+    /// It is needed to detect whether Ghidra added a constant offset to all addresses of the memory address.
+    /// E.g. if the `binary_base_address` is 0 for shared object files,
+    /// Ghidra adds an offset so that the memory image does not actually start at address 0.
+    pub fn into_ir_program(self, binary_base_address: u64) -> IrProgram {
+        let subs = self
             .subs
             .into_iter()
             .map(|sub_term| Term {
@@ -367,14 +374,18 @@ impl From<Program> for IrProgram {
                 term: sub_term.term.into(),
             })
             .collect();
+        let extern_symbols = self
+            .extern_symbols
+            .into_iter()
+            .map(|symbol| symbol.into())
+            .collect();
+        let address_base_offset =
+            u64::from_str_radix(&self.image_base, 16).unwrap() - binary_base_address;
         IrProgram {
             subs,
-            extern_symbols: program
-                .extern_symbols
-                .into_iter()
-                .map(|symbol| symbol.into())
-                .collect(),
-            entry_points: program.entry_points,
+            extern_symbols,
+            entry_points: self.entry_points,
+            address_base_offset,
         }
     }
 }
@@ -409,14 +420,17 @@ pub struct Project {
     pub register_calling_convention: Vec<CallingConvention>,
 }
 
-impl From<Project> for IrProject {
+impl Project {
     /// Convert a project parsed from Ghidra to the internally used IR.
-    fn from(project: Project) -> IrProject {
+    ///
+    /// The `binary_base_address` denotes the base address of the memory image of the binary
+    /// according to the program headers of the binary.
+    pub fn into_ir_project(self, binary_base_address: u64) -> IrProject {
         let mut program: Term<IrProgram> = Term {
-            tid: project.program.tid,
-            term: project.program.term.into(),
+            tid: self.program.tid,
+            term: self.program.term.into_ir_program(binary_base_address),
         };
-        let register_map: HashMap<&String, &RegisterProperties> = project
+        let register_map: HashMap<&String, &RegisterProperties> = self
             .register_properties
             .iter()
             .map(|p| (&p.register, p))
@@ -511,9 +525,9 @@ impl From<Project> for IrProject {
         }
         IrProject {
             program,
-            cpu_architecture: project.cpu_architecture,
-            stack_pointer_register: project.stack_pointer_register.into(),
-            calling_conventions: project
+            cpu_architecture: self.cpu_architecture,
+            stack_pointer_register: self.stack_pointer_register.into(),
+            calling_conventions: self
                 .register_calling_convention
                 .into_iter()
                 .map(|cconv| cconv.into())

--- a/cwe_checker_rs/src/pcode/term/tests.rs
+++ b/cwe_checker_rs/src/pcode/term/tests.rs
@@ -28,7 +28,8 @@ impl Setup {
                       "term": {
                         "subs": [],
                         "extern_symbols": [],
-                        "entry_points":[]
+                        "entry_points":[],
+                        "image_base": "10000"
                       }
                     },
                     "stack_pointer_register": {
@@ -560,20 +561,21 @@ fn program_deserialization() {
             "term": {
                 "subs": [],
                 "extern_symbols": [],
-                "entry_points":[]
+                "entry_points":[],
+                "image_base": "10000"
             }
             }
             "#,
     )
     .unwrap();
-    let _: IrProgram = program_term.term.into();
+    let _: IrProgram = program_term.term.into_ir_program(10000);
 }
 
 #[test]
 fn project_deserialization() {
     let setup = Setup::new();
     let project: Project = setup.project.clone();
-    let _: IrProject = project.into();
+    let _: IrProject = project.into_ir_project(10000);
 }
 
 #[test]
@@ -660,7 +662,7 @@ fn from_project_to_ir_project() {
     sub.term.blocks.push(blk);
     mock_project.program.term.subs.push(sub.clone());
 
-    let ir_program = IrProject::from(mock_project).program.term;
+    let ir_program = mock_project.into_ir_project(10000).program.term;
     let ir_rdi_var = IrVariable {
         name: String::from("RDI"),
         size: ByteSize::new(8),

--- a/cwe_checker_rs/src/term/mod.rs
+++ b/cwe_checker_rs/src/term/mod.rs
@@ -298,6 +298,7 @@ impl From<Program> for IrProgram {
                 .map(|symbol| symbol.into())
                 .collect(),
             entry_points: program.entry_points,
+            address_base_offset: 0,
         }
     }
 }

--- a/cwe_checker_rs/src/utils/mod.rs
+++ b/cwe_checker_rs/src/utils/mod.rs
@@ -2,6 +2,8 @@ pub mod graph_utils;
 pub mod log;
 pub mod symbol_utils;
 
+use crate::prelude::*;
+
 /// Get the contents of a configuration file.
 pub fn read_config_file(filename: &str) -> serde_json::Value {
     let project_dirs = directories::ProjectDirs::from("", "", "cwe_checker")
@@ -19,4 +21,23 @@ pub fn get_ghidra_plugin_path(plugin_name: &str) -> std::path::PathBuf {
         .expect("Could not discern location of data directory.");
     let data_dir = project_dirs.data_dir();
     data_dir.join("ghidra").join(plugin_name)
+}
+
+/// Get the base address for the image of a binary when loaded into memory.
+pub fn get_binary_base_address(binary: &[u8]) -> Result<u64, Error> {
+    use goblin::Object;
+    match Object::parse(binary)? {
+        Object::Elf(elf_file) => {
+            for header in elf_file.program_headers.iter() {
+                let vm_range = header.vm_range();
+                if !vm_range.is_empty() && header.p_type == goblin::elf::program_header::PT_LOAD {
+                    // The loadable segments have to occur in order in the program header table.
+                    // So the start address of the first loadable segment is the base offset of the binary.
+                    return Ok(vm_range.start as u64);
+                }
+            }
+            Err(anyhow!("No loadable segment bounds found."))
+        }
+        _ => Err(anyhow!("Binary type not yet supported")),
+    }
 }

--- a/ghidra/p_code_extractor/internal/TermCreator.java
+++ b/ghidra/p_code_extractor/internal/TermCreator.java
@@ -29,7 +29,8 @@ public class TermCreator {
      */
     public static Term<Program> createProgramTerm() {
         Tid progTid = new Tid(String.format("prog_%s", HelperFunctions.ghidraProgram.getMinAddress().toString()), HelperFunctions.ghidraProgram.getMinAddress().toString());
-        return new Term<Program>(progTid, new Program(new ArrayList<Term<Sub>>(), HelperFunctions.addEntryPoints(symTab)));
+        String imageBase = HelperFunctions.ghidraProgram.getImageBase().toString();
+        return new Term<Program>(progTid, new Program(new ArrayList<Term<Sub>>(), HelperFunctions.addEntryPoints(symTab), imageBase));
     }
 
 

--- a/ghidra/p_code_extractor/term/Program.java
+++ b/ghidra/p_code_extractor/term/Program.java
@@ -14,6 +14,8 @@ public class Program {
     private ArrayList<ExternSymbol> externSymbols;
     @SerializedName("entry_points")
     private ArrayList<Tid> entryPoints;
+    @SerializedName("image_base")
+    private String imageBase;
 
     public Program() {
     }
@@ -22,9 +24,10 @@ public class Program {
         this.setSubs(subs);
     }
 
-    public Program(ArrayList<Term<Sub>> subs, ArrayList<Tid> entryPoints) {
+    public Program(ArrayList<Term<Sub>> subs, ArrayList<Tid> entryPoints, String imageBase) {
         this.setSubs(subs);
         this.setEntryPoints(entryPoints);
+        this.setImageBase(imageBase);
     }
 
 
@@ -54,5 +57,13 @@ public class Program {
 
     public void setEntryPoints(ArrayList<Tid> entryPoints) {
         this.entryPoints = entryPoints;
+    }
+
+    public String getImageBase() {
+        return imageBase;
+    }
+
+    public void setImageBase(String imageBase) {
+        this.imageBase = imageBase;
     }
 }


### PR DESCRIPTION
This PR adds an `address_base_offset` field to the program struct. This is the difference between addresses as determined by the binary headers and addresses as determined by Ghidra.

This will be used to enable access to the correct addresses in global memory for analyses (in a future PR).