### PR TITLE
change base image of dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,31 +5,15 @@ WORKDIR /cwe_checker
 COPY . .
 RUN cargo build --release
 
-FROM phusion/baseimage:18.04-1.0.0 as runtime
+FROM fkiecad/ghidra_headless_base:9.2.1 as runtime
 
 RUN apt-get -y update \
-    && install_clean sudo \
+    && apt-get -y install sudo \
     && useradd -m cwe \
     && echo "cwe:cwe" | chpasswd \
     && adduser cwe sudo \
     && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
 USER cwe
-
-WORKDIR /home/cwe
-
-ENV PATH="/home/cwe/.cargo/bin/:${PATH}"
-ENV GHIDRA_VERSION="9.2.1_PUBLIC"
-
-# Install Ghidra
-RUN sudo apt-get -y update \
-    && sudo install_clean \
-        curl \
-        unzip \
-        openjdk-11-jdk \
-    && curl -fSL https://www.ghidra-sre.org/ghidra_9.2.1_PUBLIC_20201215.zip -o ghidra.zip \
-    && unzip -q ghidra.zip \
-    && sudo mv ghidra_${GHIDRA_VERSION} /opt/ghidra \
-    && rm ghidra.zip
 
 # Install all necessary files from the builder stage
 COPY --from=builder /cwe_checker/target/release/cwe_checker /home/cwe/cwe_checker


### PR DESCRIPTION
This PR changes the base image for the docker image to one where Ghidra is already installed. This makes the image a little bit smaller and may also save some build time for the docker image.