### PR TITLE
Bugfix Stack Register Computation

### DIFF
--- a/cwe_checker_rs/src/abstract_domain/bitvector.rs
+++ b/cwe_checker_rs/src/abstract_domain/bitvector.rs
@@ -321,10 +321,10 @@ impl std::convert::TryFrom<&BitvectorDomain> for Bitvector {
 impl std::fmt::Display for BitvectorDomain {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Self::Top(bytesize) => write!(formatter, "Top:i{}", BitSize::from(*bytesize)),
+            Self::Top(bytesize) => write!(formatter, "Top:u{}", BitSize::from(*bytesize)),
             Self::Value(bitvector) => write!(
                 formatter,
-                "0x{:016x}:i{:?}",
+                "0x{:016x}:u{:?}",
                 bitvector,
                 bitvector.width().to_usize()
             ),

--- a/cwe_checker_rs/src/analysis/pointer_inference/state/mod.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/state/mod.rs
@@ -291,24 +291,28 @@ impl State {
         self.memory.append_unknown_objects(&caller_state.memory);
     }
 
-    /// Restore the content of callee-saved registers from the caller state.
+    /// Restore the content of callee-saved registers from the caller state
+    /// with the exception of the stack register.
     ///
     /// This function does not check what the callee state currently contains in these registers.
     /// If the callee does not adhere to the given calling convention, this may introduce analysis errors!
-    /// It will also mask cases,
+    /// It will also mask cases
     /// where a callee-saved register was incorrectly modified (e.g. because of a bug in the callee).
     pub fn restore_callee_saved_register(
         &mut self,
         caller_state: &State,
         cconv: &CallingConvention,
+        stack_register: &Variable,
     ) {
         for (register, value) in caller_state.register.iter() {
-            if cconv
-                .callee_saved_register
-                .iter()
-                .any(|reg_name| *reg_name == register.name)
-            {
-                self.set_register(register, value.clone());
+            if register != stack_register {
+                if cconv
+                    .callee_saved_register
+                    .iter()
+                    .any(|reg_name| *reg_name == register.name)
+                {
+                    self.set_register(register, value.clone());
+                }
             }
         }
     }

--- a/cwe_checker_rs/src/analysis/pointer_inference/state/mod.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/state/mod.rs
@@ -305,14 +305,13 @@ impl State {
         stack_register: &Variable,
     ) {
         for (register, value) in caller_state.register.iter() {
-            if register != stack_register {
-                if cconv
+            if register != stack_register
+                && cconv
                     .callee_saved_register
                     .iter()
                     .any(|reg_name| *reg_name == register.name)
-                {
-                    self.set_register(register, value.clone());
-                }
+            {
+                self.set_register(register, value.clone());
             }
         }
     }

--- a/cwe_checker_rs/src/analysis/pointer_inference/state/tests.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/state/tests.rs
@@ -378,7 +378,7 @@ fn remove_and_restore_callee_saved_register() {
 
     let other_value: Data = Bitvector::from_u64(13).into();
     callee_state.set_register(&register("RAX"), other_value.clone());
-    callee_state.restore_callee_saved_register(&state, &cconv);
+    callee_state.restore_callee_saved_register(&state, &cconv, &register("RSP"));
     assert_eq!(callee_state.get_register(&register("RBP")).unwrap(), value);
     assert_eq!(
         callee_state.get_register(&register("RAX")).unwrap(),


### PR DESCRIPTION
This PR fixes a bug, where the stack register was overwritten on return instructions with its value before the corresponding call. This produced incorrect stack pointer values for x86 and x64 architectures.