### PR TITLE
Trivial expressions

### DIFF
--- a/cwe_checker_rs/src/intermediate_representation/expression/tests.rs
+++ b/cwe_checker_rs/src/intermediate_representation/expression/tests.rs
@@ -116,6 +116,13 @@ fn trivial_expression_substitution() {
         expr,
         Expression::Const(Bitvector::zero(ByteSize::new(8).into()))
     );
+    let mut expr = Expression::BinOp {
+        op: BinOpType::IntOr,
+        lhs: Box::new(setup.rax_variable.clone()),
+        rhs: Box::new(Expression::Const(Bitvector::zero(ByteSize::new(8).into()))),
+    };
+    expr.substitute_trivial_operations();
+    assert_eq!(expr, setup.rax_variable);
 }
 
 #[test]

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -174,13 +174,6 @@ mod tests {
         let mut error_log = Vec::new();
         let mut tests = all_test_cases("cwe_190", "CWE190");
 
-        // Ghidra does not recognize all extern function calls in the disassembly step for MIPS.
-        // Needs own control flow graph analysis to be fixed.
-        mark_skipped(&mut tests, "mips64", "clang");
-        mark_skipped(&mut tests, "mips64el", "clang");
-        mark_skipped(&mut tests, "mips", "gcc");
-        mark_skipped(&mut tests, "mipsel", "gcc");
-
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
 
@@ -289,13 +282,6 @@ mod tests {
         let mut error_log = Vec::new();
         let mut tests = all_test_cases("cwe_415", "Memory");
 
-        // Ghidra does not recognize all extern function calls in the disassembly step for MIPS.
-        // Needs own control flow graph analysis to be fixed.
-        mark_architecture_skipped(&mut tests, "mips64");
-        mark_architecture_skipped(&mut tests, "mips64el");
-        mark_architecture_skipped(&mut tests, "mips");
-        mark_architecture_skipped(&mut tests, "mipsel");
-
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
 
@@ -324,20 +310,13 @@ mod tests {
         let mut error_log = Vec::new();
         let mut tests = all_test_cases("cwe_416", "Memory");
 
-        // Ghidra does not recognize all extern function calls in the disassembly step for MIPS.
-        // Needs own control flow graph analysis to be fixed.
-        mark_architecture_skipped(&mut tests, "mips64");
-        mark_architecture_skipped(&mut tests, "mips64el");
-        mark_architecture_skipped(&mut tests, "mips");
-        mark_architecture_skipped(&mut tests, "mipsel");
-
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
 
         // The analysis loses track of the stack pointer offset in the main() function
         // because of a "INT_AND ESP 0xfffffff0" instruction.
         // We would need knowledge about alignment guarantees for the stack pointer at the start of main() to fix this.
-        mark_architecture_skipped(&mut tests, "x86");
+        mark_skipped(&mut tests, "x86", "gcc");
 
         mark_compiler_skipped(&mut tests, "mingw32-gcc"); // TODO: Check reason for failure!
 
@@ -358,13 +337,6 @@ mod tests {
     fn cwe_426() {
         let mut error_log = Vec::new();
         let mut tests = all_test_cases("cwe_426", "CWE426");
-
-        // Ghidra does not recognize all extern function calls in the disassembly step for MIPS.
-        // Needs own control flow graph analysis to be fixed.
-        mark_skipped(&mut tests, "mips64", "clang");
-        mark_skipped(&mut tests, "mips64el", "clang");
-        mark_skipped(&mut tests, "mips", "gcc");
-        mark_skipped(&mut tests, "mipsel", "gcc");
 
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
@@ -395,20 +367,11 @@ mod tests {
         mark_skipped(&mut tests, "arm", "clang");
         mark_skipped(&mut tests, "mips", "clang");
         mark_skipped(&mut tests, "mipsel", "clang");
-
-        // Ghidra does not recognize all extern function calls in the disassembly step for MIPS.
-        // Needs own control flow graph analysis to be fixed.
         mark_skipped(&mut tests, "mips64", "clang");
         mark_skipped(&mut tests, "mips64el", "clang");
-        mark_skipped(&mut tests, "mips", "gcc");
-        mark_skipped(&mut tests, "mipsel", "gcc");
 
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
-
-        // This is a bug in the handling of sub-registers.
-        // Register `ECX` is read, but the analysis doesn't know that `ECX` is a sub-register of `RCX`.
-        mark_skipped(&mut tests, "x64", "clang");
 
         mark_compiler_skipped(&mut tests, "mingw32-gcc"); // TODO: Check reason for failure!
 
@@ -429,12 +392,6 @@ mod tests {
     fn cwe_476() {
         let mut error_log = Vec::new();
         let mut tests = all_test_cases("cwe_476", "CWE476");
-
-        // TODO: Check reason for failure!
-        mark_architecture_skipped(&mut tests, "mips64");
-        mark_architecture_skipped(&mut tests, "mips64el");
-        mark_architecture_skipped(&mut tests, "mips");
-        mark_architecture_skipped(&mut tests, "mipsel");
 
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
@@ -459,9 +416,6 @@ mod tests {
         let mut error_log = Vec::new();
         let mut tests = linux_test_cases("cwe_560", "CWE560");
 
-        mark_skipped(&mut tests, "arm", "gcc"); // The parameter is loaded from global memory (which is not supported yet)
-        mark_skipped(&mut tests, "mips", "gcc"); // The parameter is loaded from global memory (which is not supported yet)
-        mark_skipped(&mut tests, "mipsel", "gcc"); // The parameter is loaded from global memory (which is not supported yet)
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
 


### PR DESCRIPTION
Substitute more examples of trivial expressions with their results. Also enable more acceptance tests.

It turns out that most of our MIPS-based analyses only failed because the analysis did not know that `a or 0` is always `a`. This is now fixed. 