### PR TITLE
Correctly deserialize FLOAT_ROUND p-code operations

### DIFF
--- a/cwe_checker_rs/src/pcode/expressions.rs
+++ b/cwe_checker_rs/src/pcode/expressions.rs
@@ -216,6 +216,7 @@ pub enum ExpressionType {
     FLOAT_SQRT,
     FLOAT_CEIL,
     FLOAT_FLOOR,
+    #[serde(alias = "ROUND")]
     FLOAT_ROUND,
     FLOAT_NAN,
 


### PR DESCRIPTION
Apparently, Ghidra uses ROUND as a mnemonic for the FLOAT_ROUND p-code operation. At least according to the p-code op code it represents the FLOAT_ROUND p-code operation. This PR fixes the deserialization of it and should be a fix for issue #141.