### PR TITLE
provide control flow graph independently of pointer inference analysis

### DIFF
--- a/caller/src/main.rs
+++ b/caller/src/main.rs
@@ -1,3 +1,4 @@
+use cwe_checker_rs::analysis::graph;
 use cwe_checker_rs::utils::binary::RuntimeMemoryImage;
 use cwe_checker_rs::utils::log::print_all_messages;
 use cwe_checker_rs::utils::{get_ghidra_plugin_path, read_config_file};
@@ -146,11 +147,24 @@ fn run_with_ghidra(args: CmdlineArgs) {
         // so that other analyses do not have to adjust their addresses.
         runtime_memory_image.add_global_memory_offset(project.program.term.address_base_offset);
     }
+    // Generate the control flow graph of the program
+    let extern_sub_tids = project
+        .program
+        .term
+        .extern_symbols
+        .iter()
+        .map(|symbol| symbol.tid.clone())
+        .collect();
+    let control_flow_graph = graph::get_program_cfg(&project.program, extern_sub_tids);
 
-    let mut analysis_results = AnalysisResults::new(&binary, &runtime_memory_image, &project);
+    let analysis_results = AnalysisResults::new(
+        &binary,
+        &runtime_memory_image,
+        &control_flow_graph,
+        &project,
+    );
 
-    let modules_depending_on_pointer_inference =
-        vec!["CWE78", "CWE243", "CWE367", "CWE476", "Memory"];
+    let modules_depending_on_pointer_inference = vec!["CWE78", "CWE476", "Memory"];
     let pointer_inference_results = if modules
         .iter()
         .any(|module| modules_depending_on_pointer_inference.contains(&module.name))
@@ -159,7 +173,8 @@ fn run_with_ghidra(args: CmdlineArgs) {
     } else {
         None
     };
-    analysis_results = analysis_results.set_pointer_inference(pointer_inference_results.as_ref());
+    let analysis_results =
+        analysis_results.set_pointer_inference(pointer_inference_results.as_ref());
 
     // Print debug and then return.
     // Right now there is only one debug printing function.
@@ -168,6 +183,7 @@ fn run_with_ghidra(args: CmdlineArgs) {
         cwe_checker_rs::analysis::pointer_inference::run(
             &project,
             &runtime_memory_image,
+            &control_flow_graph,
             serde_json::from_value(config["Memory"].clone()).unwrap(),
             true,
         );

--- a/cwe_checker_rs/src/analysis/pointer_inference/context/tests.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/context/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::HashSet;
 
 fn bv(value: i64) -> BitvectorDomain {
     BitvectorDomain::Value(Bitvector::from_i64(value))
@@ -106,8 +107,9 @@ fn context_problem_implementation() {
 
     let (project, config) = mock_project();
     let runtime_memory_image = RuntimeMemoryImage::mock();
+    let graph = crate::analysis::graph::get_program_cfg(&project.program, HashSet::new());
     let (log_sender, _log_receiver) = crossbeam_channel::unbounded();
-    let context = Context::new(&project, &runtime_memory_image, config, log_sender);
+    let context = Context::new(&project, &runtime_memory_image, &graph, config, log_sender);
     let mut state = State::new(&register("RSP"), Tid::new("main"));
 
     let def = Term {
@@ -283,9 +285,10 @@ fn update_return() {
     use crate::analysis::pointer_inference::object::ObjectType;
     use crate::analysis::pointer_inference::Data;
     let (project, config) = mock_project();
+    let graph = crate::analysis::graph::get_program_cfg(&project.program, HashSet::new());
     let runtime_memory_image = RuntimeMemoryImage::mock();
     let (log_sender, _log_receiver) = crossbeam_channel::unbounded();
-    let context = Context::new(&project, &runtime_memory_image, config, log_sender);
+    let context = Context::new(&project, &runtime_memory_image, &graph, config, log_sender);
     let state_before_return = State::new(&register("RSP"), Tid::new("callee"));
     let mut state_before_return = context
         .update_def(

--- a/cwe_checker_rs/src/analysis/pointer_inference/mod.rs
+++ b/cwe_checker_rs/src/analysis/pointer_inference/mod.rs
@@ -74,10 +74,17 @@ impl<'a> PointerInference<'a> {
     pub fn new(
         project: &'a Project,
         runtime_memory_image: &'a RuntimeMemoryImage,
+        control_flow_graph: &'a Graph<'a>,
         config: Config,
         log_sender: crossbeam_channel::Sender<LogThreadMsg>,
     ) -> PointerInference<'a> {
-        let context = Context::new(project, runtime_memory_image, config, log_sender.clone());
+        let context = Context::new(
+            project,
+            runtime_memory_image,
+            control_flow_graph,
+            config,
+            log_sender.clone(),
+        );
 
         let mut entry_sub_to_entry_blocks_map = HashMap::new();
         let subs: HashMap<Tid, &Term<Sub>> = project
@@ -405,6 +412,7 @@ pub fn extract_pi_analysis_results(
 pub fn run<'a>(
     project: &'a Project,
     runtime_memory_image: &'a RuntimeMemoryImage,
+    control_flow_graph: &'a Graph<'a>,
     config: Config,
     print_debug: bool,
 ) -> PointerInference<'a> {
@@ -413,6 +421,7 @@ pub fn run<'a>(
     let mut computation = PointerInference::new(
         project,
         runtime_memory_image,
+        control_flow_graph,
         config,
         logging_thread.get_msg_sender(),
     );
@@ -474,13 +483,14 @@ mod tests {
         pub fn mock(
             project: &'a Project,
             mem_image: &'a RuntimeMemoryImage,
+            graph: &'a Graph,
         ) -> PointerInference<'a> {
             let config = Config {
                 allocation_symbols: vec!["malloc".to_string()],
                 deallocation_symbols: vec!["free".to_string()],
             };
             let (log_sender, _) = crossbeam_channel::unbounded();
-            PointerInference::new(project, mem_image, config, log_sender)
+            PointerInference::new(project, mem_image, graph, config, log_sender)
         }
     }
 }

--- a/cwe_checker_rs/src/checkers/cwe_243.rs
+++ b/cwe_checker_rs/src/checkers/cwe_243.rs
@@ -116,7 +116,7 @@ pub fn check_cwe(
     cwe_params: &serde_json::Value,
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
     let project = analysis_results.project;
-    let graph = analysis_results.pointer_inference.unwrap().get_graph();
+    let graph = analysis_results.control_flow_graph;
 
     let config: Config = serde_json::from_value(cwe_params.clone()).unwrap();
     let priviledge_dropping_tids: Vec<Tid> = config

--- a/cwe_checker_rs/src/checkers/cwe_367.rs
+++ b/cwe_checker_rs/src/checkers/cwe_367.rs
@@ -72,7 +72,7 @@ pub fn check_cwe(
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
     let config: Config = serde_json::from_value(cwe_params.clone()).unwrap();
     let project = analysis_results.project;
-    let graph = analysis_results.pointer_inference.unwrap().get_graph();
+    let graph = analysis_results.control_flow_graph;
     let mut cwe_warnings = Vec::new();
 
     let symbol_map: HashMap<&str, Tid> = project

--- a/cwe_checker_rs/src/checkers/cwe_476/context.rs
+++ b/cwe_checker_rs/src/checkers/cwe_476/context.rs
@@ -426,6 +426,7 @@ impl<'a> crate::analysis::forward_interprocedural_fixpoint::Context<'a> for Cont
 mod tests {
     use super::*;
     use crate::utils::binary::RuntimeMemoryImage;
+    use std::collections::HashSet;
 
     impl<'a> Context<'a> {
         pub fn mock(
@@ -454,7 +455,8 @@ mod tests {
     fn check_parameter_arg_for_taint() {
         let project = Project::mock_empty();
         let runtime_memory_image = RuntimeMemoryImage::mock();
-        let pi_results = PointerInferenceComputation::mock(&project, &runtime_memory_image);
+        let graph = crate::analysis::graph::get_program_cfg(&project.program, HashSet::new());
+        let pi_results = PointerInferenceComputation::mock(&project, &runtime_memory_image, &graph);
         let context = Context::mock(&project, &runtime_memory_image, &pi_results);
         let (mut state, _pi_state) = State::mock_with_pi_state();
 
@@ -477,7 +479,8 @@ mod tests {
     fn handle_generic_call() {
         let project = Project::mock_empty();
         let runtime_memory_image = RuntimeMemoryImage::mock();
-        let pi_results = PointerInferenceComputation::mock(&project, &runtime_memory_image);
+        let graph = crate::analysis::graph::get_program_cfg(&project.program, HashSet::new());
+        let pi_results = PointerInferenceComputation::mock(&project, &runtime_memory_image, &graph);
         let context = Context::mock(&project, &runtime_memory_image, &pi_results);
         let mut state = State::mock();
 
@@ -498,7 +501,8 @@ mod tests {
     fn update_def() {
         let project = Project::mock_empty();
         let runtime_memory_image = RuntimeMemoryImage::mock();
-        let pi_results = PointerInferenceComputation::mock(&project, &runtime_memory_image);
+        let graph = crate::analysis::graph::get_program_cfg(&project.program, HashSet::new());
+        let pi_results = PointerInferenceComputation::mock(&project, &runtime_memory_image, &graph);
         let context = Context::mock(&project, &runtime_memory_image, &pi_results);
         let (mut state, pi_state) = State::mock_with_pi_state();
         state.set_pointer_inference_state(Some(pi_state));
@@ -551,7 +555,8 @@ mod tests {
     fn update_jump() {
         let project = Project::mock_empty();
         let runtime_memory_image = RuntimeMemoryImage::mock();
-        let pi_results = PointerInferenceComputation::mock(&project, &runtime_memory_image);
+        let graph = crate::analysis::graph::get_program_cfg(&project.program, HashSet::new());
+        let pi_results = PointerInferenceComputation::mock(&project, &runtime_memory_image, &graph);
         let context = Context::mock(&project, &runtime_memory_image, &pi_results);
         let (state, _pi_state) = State::mock_with_pi_state();
 

--- a/cwe_checker_rs/src/checkers/cwe_78/context/tests.rs
+++ b/cwe_checker_rs/src/checkers/cwe_78/context/tests.rs
@@ -128,7 +128,8 @@ fn setting_taint_source() {
     let current_sub = Sub::mock("func");
 
     let mem_image = RuntimeMemoryImage::mock();
-    let pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     let mem_image = RuntimeMemoryImage::mock();
     let mut context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
 
@@ -157,7 +158,8 @@ fn tainting_string_function_parameters() {
         .save_taint_to_memory(&setup.base_sixteen_offset, Taint::Tainted(ByteSize::new(8)));
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -204,7 +206,8 @@ fn first_param_pointing_to_memory_taint() {
         .set_register(&rdi_reg, setup.base_eight_offset.clone());
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -232,7 +235,8 @@ fn tainting_generic_function_parameters_and_removing_non_callee_saved() {
     let rax_reg = Variable::mock("RAX", 8 as u64);
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     setup
@@ -317,7 +321,8 @@ fn tainting_stack_parameters() {
     let stack_id = setup.pi_state.stack_id.clone();
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -355,7 +360,8 @@ fn tainting_parameters() {
     let stack_id = setup.pi_state.stack_id.clone();
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -394,7 +400,8 @@ fn creating_pi_def_map() {
     let stack_id = setup.pi_state.stack_id.clone();
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -436,7 +443,8 @@ fn getting_blk_start_node_if_last_def() {
     );
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -464,7 +472,8 @@ fn getting_source_node() {
     let call_tid = Tid::new("call_string");
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -491,7 +500,8 @@ fn updating_target_state_for_callsite() {
     let rdi_reg = Variable::mock("RDI", 8 as u64);
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -567,7 +577,8 @@ fn handling_assign_and_load() {
     let stack_id = setup.pi_state.stack_id.clone();
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -643,7 +654,8 @@ fn updating_def() {
     let stack_id = setup.pi_state.stack_id.clone();
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -724,7 +736,8 @@ fn updating_jumpsite() {
         .save_taint_to_memory(&setup.base_eight_offset, Taint::Tainted(ByteSize::new(8)));
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -770,7 +783,8 @@ fn updating_callsite() {
     let caller_sub = Sub::mock("caller");
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -861,7 +875,8 @@ fn splitting_call_stub() {
         .save_taint_to_memory(&setup.base_eight_offset, Taint::Tainted(ByteSize::new(8)));
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -906,7 +921,8 @@ fn splitting_return_stub() {
         .save_taint_to_memory(&setup.base_eight_offset, Taint::Tainted(ByteSize::new(8)));
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);
@@ -960,7 +976,8 @@ fn updating_call_stub() {
         .save_taint_to_memory(&setup.base_sixteen_offset, Taint::Tainted(ByteSize::new(8)));
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let mut string_symbols: HashMap<Tid, &ExternSymbol> = HashMap::new();
@@ -1009,7 +1026,8 @@ fn specializing_conditional() {
         .save_taint_to_memory(&setup.base_eight_offset, Taint::Tainted(ByteSize::new(8)));
 
     let mem_image = RuntimeMemoryImage::mock();
-    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image);
+    let graph = crate::analysis::graph::get_program_cfg(&setup.project.program, HashSet::new());
+    let mut pi_results = PointerInferenceComputation::mock(&setup.project, &mem_image, &graph);
     pi_results.compute();
 
     let context = Context::mock(&setup.project, HashMap::new(), &pi_results, &mem_image);


### PR DESCRIPTION
Provide access to the control flow graph independently of the pointer inference analysis.

Several analyses used the control flow graph but not the results of the pointer inference analysis. They can access the graph now without the need to run the pointer inference analysis first.