### PR TITLE
parse indirect jump targets from Ghidra

### DIFF
--- a/src/cwe_checker_lib/src/analysis/backward_interprocedural_fixpoint/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/backward_interprocedural_fixpoint/tests.rs
@@ -71,6 +71,7 @@ fn mock_program() -> Term<Program> {
         term: Blk {
             defs: vec![def_term1],
             jmps: vec![call_term],
+            indirect_jmp_targets: Vec::new(),
         },
     };
     let sub1_blk2 = Term {
@@ -78,6 +79,7 @@ fn mock_program() -> Term<Program> {
         term: Blk {
             defs: vec![def_term5],
             jmps: vec![jmp_term],
+            indirect_jmp_targets: Vec::new(),
         },
     };
     let sub1 = Term {
@@ -104,6 +106,7 @@ fn mock_program() -> Term<Program> {
         term: Blk {
             defs: vec![def_term2, def_term3],
             jmps: vec![cond_jump_term, jump_term_2],
+            indirect_jmp_targets: Vec::new(),
         },
     };
     let sub2_blk2 = Term {
@@ -111,6 +114,7 @@ fn mock_program() -> Term<Program> {
         term: Blk {
             defs: vec![def_term4],
             jmps: vec![return_term],
+            indirect_jmp_targets: Vec::new(),
         },
     };
     let sub2 = Term {

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/tests.rs
@@ -139,6 +139,7 @@ fn context_problem_implementation() {
         term: Blk {
             defs: Vec::new(),
             jmps: Vec::new(),
+            indirect_jmp_targets: Vec::new(),
         },
     };
     let sub = Term {

--- a/src/cwe_checker_lib/src/checkers/cwe_78/context/tests.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/context/tests.rs
@@ -14,6 +14,7 @@ fn mock_block(tid: &str) -> Term<Blk> {
         term: Blk {
             defs: Vec::new(),
             jmps: Vec::new(),
+            indirect_jmp_targets: Vec::new(),
         },
     }
 }

--- a/src/cwe_checker_lib/src/intermediate_representation/term.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/term.rs
@@ -252,10 +252,14 @@ impl Term<Blk> {
             .indirect_jmp_targets
             .iter()
             .filter_map(|target_address| {
-                if known_block_tids.get(&Tid::blk_id_at_address(&target_address)).is_some() {
+                if known_block_tids
+                    .get(&Tid::blk_id_at_address(&target_address))
+                    .is_some()
+                {
                     Some(target_address.to_string())
                 } else {
-                    let error_msg = format!("Indirect jump target at {} does not exist", target_address);
+                    let error_msg =
+                        format!("Indirect jump target at {} does not exist", target_address);
                     logs.push(LogMessage::new_error(error_msg).location(self.tid.clone()));
                     None
                 }
@@ -483,7 +487,9 @@ impl Project {
         let mut log_messages = Vec::new();
         for sub in self.program.term.subs.iter_mut() {
             for block in sub.term.blocks.iter_mut() {
-                if let Err(mut logs) = block.remove_nonexisting_indirect_jump_targets(&jump_target_tids) {
+                if let Err(mut logs) =
+                    block.remove_nonexisting_indirect_jump_targets(&jump_target_tids)
+                {
                     log_messages.append(&mut logs);
                 }
                 for jmp in block.term.jmps.iter_mut() {

--- a/src/cwe_checker_lib/src/intermediate_representation/term.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/term.rs
@@ -32,6 +32,18 @@ impl Tid {
             address: self.address,
         }
     }
+
+    /// Generate the ID of a block starting at the given address.
+    ///
+    /// Note that the block may not actually exist.
+    /// For cases where one assembly instruction generates more than one block,
+    /// the returned block ID is the one that would be executed first if a jump to the given address happened.
+    pub fn blk_id_at_address(address: &str) -> Tid {
+        Tid {
+            id: format!("blk_{}", address),
+            address: address.to_string(),
+        }
+    }
 }
 
 impl std::fmt::Display for Tid {
@@ -212,6 +224,10 @@ impl Term<Jmp> {
 /// - For two jumps, the first one has to be a conditional jump,
 /// where the second unconditional jump is only taken if the condition of the first jump evaluates to false.
 ///
+/// If one of the `Jmp` instructions is an indirect jump,
+/// then the `indirect_jmp_targets` is a list of possible jump target addresses for that jump.
+/// The list may not be complete and the entries are not guaranteed to be correct.
+///
 /// Basic blocks are *single entry, single exit*, i.e. a basic block is only entered at the beginning
 /// and is only exited by the jump instructions at the end of the block.
 /// If a new control flow edge is discovered that would jump to the middle of a basic block,
@@ -220,6 +236,7 @@ impl Term<Jmp> {
 pub struct Blk {
     pub defs: Vec<Term<Def>>,
     pub jmps: Vec<Term<Jmp>>,
+    pub indirect_jmp_targets: Vec<String>,
 }
 
 /// A `Sub` or subroutine represents a function with a given name and a list of basic blocks belonging to it.
@@ -458,6 +475,7 @@ impl Project {
                         term: Blk {
                             defs: Vec::new(),
                             jmps: Vec::new(),
+                            indirect_jmp_targets: Vec::new(),
                         },
                     }],
                 },
@@ -492,6 +510,7 @@ mod tests {
                 term: Blk {
                     defs: Vec::new(),
                     jmps: Vec::new(),
+                    indirect_jmp_targets: Vec::new(),
                 },
             }
         }

--- a/src/cwe_checker_lib/src/pcode/term.rs
+++ b/src/cwe_checker_lib/src/pcode/term.rs
@@ -30,6 +30,7 @@ pub struct Jmp {
     pub goto: Option<Label>,
     pub call: Option<Call>,
     pub condition: Option<Variable>,
+    pub target_hints: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
@@ -199,6 +200,11 @@ impl From<Blk> for IrBlk {
                 term: def_term.term.into(),
             })
             .collect();
+        let indirect_jmp_targets = blk
+            .jmps
+            .iter()
+            .find_map(|jmp_term| jmp_term.term.target_hints.clone())
+            .unwrap_or_default();
         let jmps: Vec<Term<IrJmp>> = blk
             .jmps
             .into_iter()
@@ -207,7 +213,11 @@ impl From<Blk> for IrBlk {
                 term: jmp_term.term.into(),
             })
             .collect();
-        IrBlk { defs, jmps }
+        IrBlk {
+            defs,
+            jmps,
+            indirect_jmp_targets,
+        }
     }
 }
 

--- a/src/ghidra/p_code_extractor/term/Jmp.java
+++ b/src/ghidra/p_code_extractor/term/Jmp.java
@@ -3,6 +3,7 @@ package term;
 import bil.ExecutionType;
 import bil.Variable;
 
+import java.util.ArrayList;
 import com.google.gson.annotations.SerializedName;
 
 public class Jmp {
@@ -19,6 +20,8 @@ public class Jmp {
     private Variable condition;
     @SerializedName("pcode_index")
     private int pcodeIndex;
+    @SerializedName("target_hints")
+    private ArrayList<String> targetHints;
 
     public Jmp() {
     }
@@ -93,4 +96,11 @@ public class Jmp {
         this.pcodeIndex = pcodeIndex;
     }
 
+    public ArrayList<String> getTargetHints() {
+        return targetHints;
+    }
+
+    public void setTargetHints(ArrayList<String> targetHints) {
+        this.targetHints = targetHints;
+    }
 }


### PR DESCRIPTION
Parse indirect jump targets from the Ghidra backend and add them to the control flow graph. This PR only handles intraprocedural indirect jumps but not indirect calls!