### PR TITLE
Use IntervalDomain in Pointer Inference analysis

### DIFF
--- a/src/cwe_checker_lib/src/abstract_domain/bitvector.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/bitvector.rs
@@ -1,4 +1,5 @@
-use super::{AbstractDomain, HasTop, RegisterDomain, SizedDomain};
+use super::Interval;
+use super::{AbstractDomain, HasTop, RegisterDomain, SizedDomain, TryToBitvec, TryToInterval};
 use crate::intermediate_representation::*;
 use crate::prelude::*;
 
@@ -141,12 +142,22 @@ impl std::convert::From<Bitvector> for BitvectorDomain {
     }
 }
 
-impl std::convert::TryFrom<&BitvectorDomain> for Bitvector {
-    type Error = ();
-    fn try_from(bitvec_domain: &BitvectorDomain) -> Result<Bitvector, ()> {
-        match bitvec_domain {
-            BitvectorDomain::Value(bitvec) => Ok(bitvec.clone()),
-            BitvectorDomain::Top(_) => Err(()),
+impl TryToBitvec for BitvectorDomain {
+    /// If the domain represents an absoulute value, return it.
+    fn try_to_bitvec(&self) -> Result<Bitvector, Error> {
+        match self {
+            BitvectorDomain::Value(val) => Ok(val.clone()),
+            BitvectorDomain::Top(_) => Err(anyhow!("Value is Top")),
+        }
+    }
+}
+
+impl TryToInterval for BitvectorDomain {
+    /// If the domain represents an absolute value, return it as an interval of length one.
+    fn try_to_interval(&self) -> Result<Interval, Error> {
+        match self {
+            BitvectorDomain::Value(val) => Ok(Interval::new(val.clone(), val.clone())),
+            BitvectorDomain::Top(_) => Err(anyhow!("Value is Top")),
         }
     }
 }

--- a/src/cwe_checker_lib/src/abstract_domain/mem_region.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/mem_region.rs
@@ -109,6 +109,16 @@ impl<T: AbstractDomain + SizedDomain + HasTop + std::fmt::Debug> MemRegionData<T
         }
     }
 
+    /// Clear all values that might be overwritten if one writes a value with byte size `value_size`
+    /// to an offset contained in the interval from `start` to `end` (both bounds included in the interval).
+    ///
+    /// This represents the effect of writing an arbitrary value (with known byte size)
+    /// to an arbitrary offset contained in the interval.
+    pub fn clear_offset_interval(&mut self, start: i64, end: i64, value_size: ByteSize) {
+        let size = end - start + (u64::from(value_size) as i64);
+        self.clear_interval(start, size);
+    }
+
     /// Add a value to the memory region.
     pub fn add(&mut self, value: T, position: Bitvector) {
         assert_eq!(ByteSize::from(position.width()), self.address_bytesize);

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/mod.rs
@@ -7,6 +7,7 @@ use crate::{abstract_domain::*, utils::binary::RuntimeMemoryImage};
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::state::State;
+use super::ValueDomain;
 use super::{Config, Data, VERSION};
 
 // contains trait implementations for the `Context` struct,
@@ -380,7 +381,7 @@ impl<'a> Context<'a> {
     }
 
     /// Get the offset of the current stack pointer to the base of the current stack frame.
-    fn get_current_stack_offset(&self, state: &State) -> BitvectorDomain {
+    fn get_current_stack_offset(&self, state: &State) -> ValueDomain {
         if let Ok(Data::Pointer(ref stack_pointer)) =
             state.get_register(&self.project.stack_pointer_register)
         {
@@ -388,16 +389,11 @@ impl<'a> Context<'a> {
                 let (stack_id, stack_offset_domain) =
                     stack_pointer.targets().iter().next().unwrap();
                 if *stack_id == state.stack_id {
-                    stack_offset_domain.clone()
-                } else {
-                    BitvectorDomain::new_top(stack_pointer.bytesize())
+                    return stack_offset_domain.clone();
                 }
-            } else {
-                BitvectorDomain::new_top(self.project.stack_pointer_register.size)
             }
-        } else {
-            BitvectorDomain::new_top(self.project.stack_pointer_register.size)
         }
+        ValueDomain::new_top(self.project.stack_pointer_register.size)
     }
 }
 

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use std::collections::HashSet;
 
-fn bv(value: i64) -> BitvectorDomain {
-    BitvectorDomain::Value(Bitvector::from_i64(value))
+fn bv(value: i64) -> ValueDomain {
+    ValueDomain::from(Bitvector::from_i64(value))
 }
 
 fn new_id(time: &str, reg_name: &str) -> AbstractIdentifier {

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
@@ -21,7 +21,7 @@ use crate::intermediate_representation::*;
 use crate::prelude::*;
 use crate::utils::log::*;
 use crate::{
-    abstract_domain::{BitvectorDomain, DataDomain},
+    abstract_domain::{DataDomain, IntervalDomain},
     utils::binary::RuntimeMemoryImage,
 };
 use petgraph::graph::NodeIndex;
@@ -47,8 +47,11 @@ pub static CWE_MODULE: crate::CweModule = crate::CweModule {
     run: extract_pi_analysis_results,
 };
 
+/// The abstract domain to use for absolute values.
+pub type ValueDomain = IntervalDomain;
+
 /// The abstract domain type for representing register values.
-pub type Data = DataDomain<BitvectorDomain>;
+pub type Data = DataDomain<ValueDomain>;
 
 /// Configurable parameters for the analysis.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/object.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/object.rs
@@ -1,6 +1,6 @@
 //! This module contains the definition of the abstract memory object type.
 
-use super::Data;
+use super::{Data, ValueDomain};
 use crate::abstract_domain::*;
 use crate::prelude::*;
 use derive_more::Deref;
@@ -72,20 +72,23 @@ impl AbstractObjectInfo {
     ///
     /// If the abstract object is not unique (i.e. may represent more than one actual object),
     /// merge the old value at the given offset with the new value.
-    pub fn set_value(&mut self, value: Data, offset: &BitvectorDomain) -> Result<(), Error> {
+    pub fn set_value(&mut self, value: Data, offset: &ValueDomain) -> Result<(), Error> {
         if let Data::Pointer(ref pointer) = value {
             self.pointer_targets.extend(pointer.ids().cloned());
         };
-        if let BitvectorDomain::Value(ref concrete_offset) = offset {
+        if let Ok(concrete_offset) = offset.try_to_bitvec() {
             if self.is_unique {
-                self.memory.add(value, concrete_offset.clone());
+                self.memory.add(value, concrete_offset);
             } else {
                 let merged_value = self
                     .memory
                     .get(concrete_offset.clone(), value.bytesize())
                     .merge(&value);
-                self.memory.add(merged_value, concrete_offset.clone());
+                self.memory.add(merged_value, concrete_offset);
             };
+        } else if let Ok((start, end)) = offset.try_to_offset_interval() {
+            self.memory
+                .clear_offset_interval(start, end, value.bytesize());
         } else {
             self.memory = MemRegion::new(self.memory.get_address_bytesize());
         }
@@ -93,16 +96,19 @@ impl AbstractObjectInfo {
     }
 
     /// Merge `value` at position `offset` with the value currently saved at that position.
-    pub fn merge_value(&mut self, value: Data, offset: &BitvectorDomain) {
+    pub fn merge_value(&mut self, value: Data, offset: &ValueDomain) {
         if let Data::Pointer(ref pointer) = value {
             self.pointer_targets.extend(pointer.ids().cloned());
         };
-        if let BitvectorDomain::Value(ref concrete_offset) = offset {
+        if let Ok(concrete_offset) = offset.try_to_bitvec() {
             let merged_value = self
                 .memory
                 .get(concrete_offset.clone(), value.bytesize())
                 .merge(&value);
-            self.memory.add(merged_value, concrete_offset.clone());
+            self.memory.add(merged_value, concrete_offset);
+        } else if let Ok((start, end)) = offset.try_to_offset_interval() {
+            self.memory
+                .clear_offset_interval(start, end, value.bytesize());
         } else {
             self.memory = MemRegion::new(self.memory.get_address_bytesize());
         }
@@ -131,7 +137,7 @@ impl AbstractObjectInfo {
         &mut self,
         old_id: &AbstractIdentifier,
         new_id: &AbstractIdentifier,
-        offset_adjustment: &BitvectorDomain,
+        offset_adjustment: &ValueDomain,
     ) {
         for elem in self.memory.values_mut() {
             elem.replace_abstract_id(old_id, new_id, offset_adjustment);
@@ -323,8 +329,8 @@ mod tests {
         Data::Value(bv(number))
     }
 
-    fn bv(number: i64) -> BitvectorDomain {
-        BitvectorDomain::Value(Bitvector::from_i64(number))
+    fn bv(number: i64) -> ValueDomain {
+        ValueDomain::from(Bitvector::from_i64(number))
     }
 
     fn new_id(tid: &str, reg_name: &str) -> AbstractIdentifier {
@@ -353,10 +359,10 @@ mod tests {
             object.get_value(Bitvector::from_i64(-15), ByteSize::new(8)),
             Data::Top(ByteSize::new(8))
         );
-        object.merge_value(new_data(5), &bv(-12));
+        object.merge_value(new_data(23), &bv(-12));
         assert_eq!(
             object.get_value(Bitvector::from_i64(-12), ByteSize::new(8)),
-            Data::Value(BitvectorDomain::new_top(ByteSize::new(8)))
+            Data::Value(ValueDomain::new_top(ByteSize::new(8)))
         );
 
         let mut other_object = new_abstract_object();

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/state/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/state/mod.rs
@@ -1,5 +1,5 @@
 use super::object_list::AbstractObjectList;
-use super::Data;
+use super::{Data, ValueDomain};
 use crate::abstract_domain::*;
 use crate::intermediate_representation::*;
 use crate::prelude::*;
@@ -124,7 +124,7 @@ impl State {
         &mut self,
         old_id: &AbstractIdentifier,
         new_id: &AbstractIdentifier,
-        offset_adjustment: &BitvectorDomain,
+        offset_adjustment: &ValueDomain,
     ) {
         for register_data in self.register.values_mut() {
             register_data.replace_abstract_id(old_id, new_id, &(-offset_adjustment.clone()));
@@ -226,7 +226,7 @@ impl State {
         &mut self,
         callee_id: &AbstractIdentifier,
         caller_id: &AbstractIdentifier,
-        offset_adjustment: &BitvectorDomain,
+        offset_adjustment: &ValueDomain,
     ) {
         self.memory.remove_object(callee_id);
         self.replace_abstract_id(callee_id, caller_id, offset_adjustment);
@@ -239,7 +239,7 @@ impl State {
     /// an error with the list of possibly already freed objects is returned.
     pub fn mark_mem_object_as_freed(
         &mut self,
-        object_pointer: &PointerDomain<BitvectorDomain>,
+        object_pointer: &PointerDomain<ValueDomain>,
     ) -> Result<(), Vec<(AbstractIdentifier, Error)>> {
         self.memory.mark_mem_object_as_freed(object_pointer)
     }

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::utils::binary::RuntimeMemoryImage;
 
-fn bv(value: i64) -> BitvectorDomain {
-    BitvectorDomain::Value(Bitvector::from_i64(value))
+fn bv(value: i64) -> ValueDomain {
+    ValueDomain::from(Bitvector::from_i64(value))
 }
 
 fn new_id(time: &str, register: &str) -> AbstractIdentifier {
@@ -418,7 +418,7 @@ fn reachable_ids_under_and_overapproximation() {
     );
 
     let _ = state.store_value(
-        &PointerDomain::new(stack_id.clone(), BitvectorDomain::new_top(ByteSize::new(8))).into(),
+        &PointerDomain::new(stack_id.clone(), ValueDomain::new_top(ByteSize::new(8))).into(),
         &Data::Value(Bitvector::from_i64(42).into()),
         &global_memory,
     );

--- a/src/cwe_checker_lib/src/checkers/cwe_467.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_467.rs
@@ -20,7 +20,7 @@
 //! - If the incorrect size value is generated before the basic block that contains
 //! the call, the check will not be able to find it.
 
-use crate::abstract_domain::{BitvectorDomain, DataDomain};
+use crate::abstract_domain::TryToBitvec;
 use crate::analysis::pointer_inference::State;
 use crate::intermediate_representation::*;
 use crate::prelude::*;
@@ -79,11 +79,13 @@ fn check_for_pointer_sized_arg(
     let pointer_size = project.stack_pointer_register.size;
     let state = compute_block_end_state(project, global_memory, block);
     for parameter in symbol.parameters.iter() {
-        if let Ok(DataDomain::Value(BitvectorDomain::Value(param_value))) =
+        if let Ok(param) =
             state.eval_parameter_arg(parameter, &project.stack_pointer_register, global_memory)
         {
-            if Ok(u64::from(pointer_size)) == param_value.try_to_u64() {
-                return true;
+            if let Ok(param_value) = param.try_to_bitvec() {
+                if Ok(u64::from(pointer_size)) == param_value.try_to_u64() {
+                    return true;
+                }
             }
         }
     }

--- a/src/cwe_checker_lib/src/checkers/cwe_560.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_560.rs
@@ -22,7 +22,7 @@
 //! - If the input to umask is not defined in the basic block before the call, the check will not see it.
 //! However, a log message will be generated whenever the check is unable to determine the parameter value of umask.
 
-use crate::abstract_domain::{BitvectorDomain, DataDomain};
+use crate::abstract_domain::TryToBitvec;
 use crate::analysis::pointer_inference::State;
 use crate::intermediate_representation::*;
 use crate::prelude::*;
@@ -72,7 +72,7 @@ fn get_umask_permission_arg(
     let parameter = umask_symbol.get_unique_parameter()?;
     let param_value =
         state.eval_parameter_arg(parameter, &project.stack_pointer_register, global_memory)?;
-    if let DataDomain::Value(BitvectorDomain::Value(umask_arg)) = param_value {
+    if let Ok(umask_arg) = param_value.try_to_bitvec() {
         Ok(umask_arg.try_to_u64()?)
     } else {
         Err(anyhow!("Parameter value unknown"))

--- a/src/cwe_checker_lib/src/checkers/cwe_78/context/tests.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/context/tests.rs
@@ -2,8 +2,8 @@ use super::*;
 
 use crate::analysis::backward_interprocedural_fixpoint::Context as BackwardContext;
 use crate::{
-    abstract_domain::{BitvectorDomain, DataDomain, PointerDomain, SizedDomain},
-    analysis::pointer_inference::{Data, State as PointerInferenceState},
+    abstract_domain::{DataDomain, PointerDomain, SizedDomain},
+    analysis::pointer_inference::{Data, State as PointerInferenceState, ValueDomain},
     intermediate_representation::{Expression, Variable},
 };
 
@@ -19,8 +19,8 @@ fn mock_block(tid: &str) -> Term<Blk> {
     }
 }
 
-fn bv(value: i64) -> BitvectorDomain {
-    BitvectorDomain::Value(Bitvector::from_i64(value))
+fn bv(value: i64) -> ValueDomain {
+    ValueDomain::from(Bitvector::from_i64(value))
 }
 
 impl ExternSymbol {
@@ -42,8 +42,8 @@ struct Setup {
     pi_state: PointerInferenceState,
     string_sym: ExternSymbol,
     taint_source: Term<Jmp>,
-    base_eight_offset: DataDomain<BitvectorDomain>,
-    base_sixteen_offset: DataDomain<BitvectorDomain>,
+    base_eight_offset: DataDomain<ValueDomain>,
+    base_sixteen_offset: DataDomain<ValueDomain>,
 }
 
 impl Setup {

--- a/src/cwe_checker_lib/src/checkers/cwe_78/state/tests.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/state/tests.rs
@@ -1,3 +1,4 @@
+use crate::analysis::pointer_inference::ValueDomain;
 use crate::{
     abstract_domain::{DataDomain, PointerDomain},
     intermediate_representation::CastOpType,
@@ -17,8 +18,8 @@ fn extern_symbol(name: &str, return_args: Vec<Arg>) -> ExternSymbol {
     }
 }
 
-fn bv(value: i64) -> BitvectorDomain {
-    BitvectorDomain::Value(Bitvector::from_i64(value))
+fn bv(value: i64) -> ValueDomain {
+    ValueDomain::from(Bitvector::from_i64(value))
 }
 
 impl State {
@@ -78,9 +79,9 @@ struct Setup {
     rsp: Variable,
     constant: Bitvector,
     def_tid: Tid,
-    stack_pointer: DataDomain<BitvectorDomain>,
-    base_eight_offset: DataDomain<BitvectorDomain>,
-    base_sixteen_offset: DataDomain<BitvectorDomain>,
+    stack_pointer: DataDomain<ValueDomain>,
+    base_eight_offset: DataDomain<ValueDomain>,
+    base_sixteen_offset: DataDomain<ValueDomain>,
 }
 
 impl Setup {


### PR DESCRIPTION
Use the interval domain for the pointer inference analysis. We do not yet take advantage of the capabilities of the interval domain (this will be done in the next couple PRs). Instead the pointer inference is generalized (to a degree) so that one can plug in different domains for representing absolute values into the analysis.