### PR TITLE
Bugfix function entry points

### DIFF
--- a/src/cwe_checker_lib/src/abstract_domain/interval/bin_ops.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/bin_ops.rs
@@ -147,10 +147,15 @@ impl IntervalDomain {
     /// The result is only exact if the `rhs` interval contains exactly one value.
     pub fn shift_left(&self, rhs: &Self) -> Self {
         if rhs.interval.start == rhs.interval.end {
-            let multiplicator = Bitvector::one(self.bytesize().into())
-                .into_checked_shl(rhs.interval.start.try_to_u64().unwrap() as usize)
+            let shift_amount = rhs.interval.start.try_to_u64().unwrap() as usize;
+            if shift_amount < self.bytesize().as_bit_length() {
+                let multiplicator = Bitvector::one(self.bytesize().into())
+                .into_checked_shl(shift_amount)
                 .unwrap();
             self.signed_mul(&multiplicator.into())
+            } else {
+                Bitvector::zero(self.bytesize().into()).into()
+            }
         } else {
             Self::new_top(self.bytesize())
         }

--- a/src/cwe_checker_lib/src/abstract_domain/interval/bin_ops.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/bin_ops.rs
@@ -150,9 +150,9 @@ impl IntervalDomain {
             let shift_amount = rhs.interval.start.try_to_u64().unwrap() as usize;
             if shift_amount < self.bytesize().as_bit_length() {
                 let multiplicator = Bitvector::one(self.bytesize().into())
-                .into_checked_shl(shift_amount)
-                .unwrap();
-            self.signed_mul(&multiplicator.into())
+                    .into_checked_shl(shift_amount)
+                    .unwrap();
+                self.signed_mul(&multiplicator.into())
             } else {
                 Bitvector::zero(self.bytesize().into()).into()
             }

--- a/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
@@ -310,4 +310,8 @@ fn shift_left() {
         result,
         IntervalDomain::mock_i8_with_bounds(None, 6, 8, None)
     );
+    let lhs = IntervalDomain::mock_with_bounds(Some(2), 3, 4, Some(64));
+    let rhs = IntervalDomain::mock_i8_with_bounds(None, 127, 127, None);
+    let result = lhs.bin_op(BinOpType::IntLeft, &rhs);
+    assert_eq!(result, IntervalDomain::mock(0, 0));
 }

--- a/src/cwe_checker_lib/src/pcode/term/tests.rs
+++ b/src/cwe_checker_lib/src/pcode/term/tests.rs
@@ -503,7 +503,47 @@ fn arg_deserialization() {
 fn sub_deserialization() {
     let setup = Setup::new();
     let sub_term: Term<Sub> = setup.sub_t.clone();
-    let _: IrSub = sub_term.term.into();
+    let _: Term<IrSub> = sub_term.into();
+    let sub_term: Term<Sub> = serde_json::from_str(
+        r#"
+          {
+          "tid": {
+              "id": "sub_00101000",
+              "address": "00101000"
+          },
+          "term": {
+              "name": "sub_name",
+              "blocks": [
+                {
+                  "tid": {
+                      "id": "blk_0010030",
+                      "address": "00100030"
+                  },
+                  "term": {
+                      "defs": [],
+                      "jmps": []
+                  }
+                },
+                {
+                  "tid": {
+                      "id": "blk_00101000",
+                      "address": "00101000"
+                  },
+                  "term": {
+                      "defs": [],
+                      "jmps": []
+                  }
+                }
+              ]
+          }
+          }
+          "#,
+    )
+    .unwrap();
+    // Example has special case where the starting block has to be corrected
+    assert!(sub_term.tid.address != sub_term.term.blocks[0].tid.address);
+    let ir_sub: Term<IrSub> = sub_term.into();
+    assert_eq!(ir_sub.tid.address, ir_sub.term.blocks[0].tid.address);
 }
 
 #[test]


### PR DESCRIPTION
Two bugfixes:
- Sometimes the wrong entry point for a function was used. This is now detected and automatically corrected when converting P-Code to the internal intermediate representation.
- In `IntervalDomain` the `shift_left` operation threw an exception for shift amounts larger than the target bitsize instead of setting the result to zero.