### PR TITLE
Bugfixes

### DIFF
--- a/src/cwe_checker_lib/src/abstract_domain/data.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/data.rs
@@ -201,7 +201,10 @@ impl<T: RegisterDomain> RegisterDomain for DataDomain<T> {
         if let Self::Value(value) = self {
             Self::Value(value.un_op(op))
         } else {
-            Self::new_top(self.bytesize())
+            match op {
+                UnOpType::BoolNegate | UnOpType::FloatNaN => Self::new_top(ByteSize::new(1)),
+                _ => Self::new_top(self.bytesize()),
+            }
         }
     }
 
@@ -422,5 +425,13 @@ mod tests {
         data = bv(42).into();
         data.remove_ids(&ids_to_remove);
         assert_eq!(data, bv(42).into());
+    }
+
+    #[test]
+    fn float_nan_bytesize() {
+        let top_value: DataDomain<BitvectorDomain> = DataDomain::new_top(ByteSize::new(8));
+        let result = top_value.un_op(UnOpType::FloatNaN);
+        assert!(result.is_top());
+        assert_eq!(result.bytesize(), ByteSize::new(1));
     }
 }

--- a/src/cwe_checker_lib/src/abstract_domain/interval.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval.rs
@@ -440,9 +440,10 @@ impl RegisterDomain for IntervalDomain {
                     IntervalDomain::new_top(self.bytesize())
                 }
             }
-            FloatAbs | FloatCeil | FloatFloor | FloatNaN | FloatNegate | FloatRound | FloatSqrt => {
+            FloatAbs | FloatCeil | FloatFloor | FloatNegate | FloatRound | FloatSqrt => {
                 IntervalDomain::new_top(self.bytesize())
             }
+            FloatNaN => IntervalDomain::new_top(ByteSize::new(1)),
         }
     }
 

--- a/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
@@ -503,3 +503,11 @@ fn intersection() {
     );
     assert!(interval1.intersect(&IntervalDomain::mock(50, 55)).is_err());
 }
+
+#[test]
+fn float_nan_bytesize() {
+    let top_value = IntervalDomain::new_top(ByteSize::new(8));
+    let result = top_value.un_op(UnOpType::FloatNaN);
+    assert!(result.is_top());
+    assert_eq!(result.bytesize(), ByteSize::new(1));
+}

--- a/src/cwe_checker_lib/src/pcode/term.rs
+++ b/src/cwe_checker_lib/src/pcode/term.rs
@@ -669,23 +669,23 @@ impl Project {
 
         // remove all blocks from functions that have no correct starting block and generate a log-message.
         for sub in self.program.term.subs.iter_mut() {
-            if !sub.term.blocks.is_empty() && sub.tid.address != sub.term.blocks[0].tid.address {
-                if sub
+            if !sub.term.blocks.is_empty()
+                && sub.tid.address != sub.term.blocks[0].tid.address
+                && sub
                     .term
                     .blocks
                     .iter()
                     .find(|block| block.tid.address == sub.tid.address)
                     .is_none()
-                {
-                    log_messages.push(LogMessage::new_error(format!(
-                        "Starting block of function {} ({}) not found.",
-                        sub.term.name, sub.tid
-                    )));
-                    sub.term.blocks = Vec::new();
-                }
+            {
+                log_messages.push(LogMessage::new_error(format!(
+                    "Starting block of function {} ({}) not found.",
+                    sub.term.name, sub.tid
+                )));
+                sub.term.blocks = Vec::new();
             }
         }
-        
+
         log_messages
     }
 }

--- a/src/cwe_checker_lib/src/pcode/term.rs
+++ b/src/cwe_checker_lib/src/pcode/term.rs
@@ -13,6 +13,7 @@ use crate::intermediate_representation::Program as IrProgram;
 use crate::intermediate_representation::Project as IrProject;
 use crate::intermediate_representation::Sub as IrSub;
 use crate::prelude::*;
+use crate::utils::log::LogMessage;
 
 // TODO: Handle the case where an indirect tail call is represented by CALLIND plus RETURN
 
@@ -641,7 +642,18 @@ impl Project {
     ///
     /// Ghidra generates implicit loads for memory accesses, whose address is a constant.
     /// The pass converts them to explicit `LOAD` instructions.
-    pub fn normalize(&mut self) {
+    ///
+    /// ### Remove basic blocks of functions without correct starting block
+    ///
+    /// Sometimes Ghidra generates a (correct) function start inside another function.
+    /// But if the function start is not also the start of a basic block,
+    /// we cannot handle it correctly (yet) as this would need splitting of basic blocks.
+    /// So instead we generate a log message and handle the function as a function without code,
+    /// i.e. a dead end in the control flow graph.
+    #[must_use]
+    pub fn normalize(&mut self) -> Vec<LogMessage> {
+        let mut log_messages = Vec::new();
+
         // Insert explicit `LOAD` instructions for implicit memory loads in P-Code.
         let generic_pointer_size = self.stack_pointer_register.size;
         for sub in self.program.term.subs.iter_mut() {
@@ -654,6 +666,27 @@ impl Project {
                 }
             }
         }
+
+        // remove all blocks from functions that have no correct starting block and generate a log-message.
+        for sub in self.program.term.subs.iter_mut() {
+            if !sub.term.blocks.is_empty() && sub.tid.address != sub.term.blocks[0].tid.address {
+                if sub
+                    .term
+                    .blocks
+                    .iter()
+                    .find(|block| block.tid.address == sub.tid.address)
+                    .is_none()
+                {
+                    log_messages.push(LogMessage::new_error(format!(
+                        "Starting block of function {} ({}) not found.",
+                        sub.term.name, sub.tid
+                    )));
+                    sub.term.blocks = Vec::new();
+                }
+            }
+        }
+        
+        log_messages
     }
 }
 


### PR DESCRIPTION
Fixes two bugs:
- When Ghidra reports a function without a basic block at that address, we now report it as a log message and treat the function as a dead end instead of panicking.
- The byte size of the `FloatNaN` unary operation was sometimes incorrectly set to the input byte size. Now it is correctly set to 1.

Closes #161.