### PR TITLE
Widening delay

### DIFF
--- a/src/cwe_checker_lib/src/abstract_domain/interval.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval.rs
@@ -256,7 +256,8 @@ impl IntervalDomain {
         let max = Bitvector::signed_max_value(size.into())
             .into_sign_extend(self.bytesize())
             .unwrap();
-        min.checked_sle(&self.interval.start).unwrap() && max.checked_sge(&self.interval.end).unwrap()
+        min.checked_sle(&self.interval.start).unwrap()
+            && max.checked_sge(&self.interval.end).unwrap()
     }
 }
 

--- a/src/cwe_checker_lib/src/abstract_domain/interval.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval.rs
@@ -166,7 +166,8 @@ impl IntervalDomain {
             has_been_widened = true;
         }
         if has_been_widened {
-            merged_domain.widening_delay = merged_domain.interval.length().try_to_u64().unwrap_or(0);
+            merged_domain.widening_delay =
+                merged_domain.interval.length().try_to_u64().unwrap_or(0);
             merged_domain
         } else {
             // No widening bounds could be used for widening, so we have to widen to the `Top` value.

--- a/src/cwe_checker_lib/src/abstract_domain/interval/bin_ops.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/bin_ops.rs
@@ -8,6 +8,7 @@ impl IntervalDomain {
         if interval.is_top() {
             interval
         } else {
+            interval.widening_delay = std::cmp::max(self.widening_delay, rhs.widening_delay);
             interval.update_widening_lower_bound(
                 &self
                     .widening_lower_bound
@@ -41,6 +42,7 @@ impl IntervalDomain {
         if interval.is_top() {
             interval
         } else {
+            interval.widening_delay = std::cmp::max(self.widening_delay, rhs.widening_delay);
             interval.update_widening_lower_bound(
                 &self
                     .widening_lower_bound
@@ -131,6 +133,7 @@ impl IntervalDomain {
                 interval,
                 widening_lower_bound: lower_bound,
                 widening_upper_bound: upper_bound,
+                widening_delay: std::cmp::max(self.widening_delay, rhs.widening_delay),
             }
         }
     }

--- a/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
@@ -511,7 +511,10 @@ fn add_not_equal_bounds() {
 
     let interval = IntervalDomain::mock_with_bounds(None, 5, 6, Some(100));
     let x = interval.add_not_equal_bound(&Bitvector::from_i64(10));
-    assert_eq!(x.unwrap(), IntervalDomain::mock_with_bounds(None, 5, 6, Some(9)));
+    assert_eq!(
+        x.unwrap(),
+        IntervalDomain::mock_with_bounds(None, 5, 6, Some(9))
+    );
 }
 
 #[test]

--- a/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
@@ -145,7 +145,7 @@ fn cast_zero_and_signed_extend() {
     let extended_val = val.cast(CastOpType::IntZExt, ByteSize::new(8));
     assert_eq!(
         extended_val,
-        IntervalDomain::mock_with_bounds(Some(236), 246, 251, Some(255))
+        IntervalDomain::mock_with_bounds(Some(236), 246, 251, None)
     );
 
     // Sign extend
@@ -171,7 +171,7 @@ fn cast_zero_and_signed_extend() {
     let extended_val = val.cast(CastOpType::IntSExt, ByteSize::new(8));
     assert_eq!(
         extended_val,
-        IntervalDomain::mock_with_bounds(Some(-128), -10, -5, Some(127))
+        IntervalDomain::mock_with_bounds(None, -10, -5, None)
     );
     let val = IntervalDomain::mock_i8_with_bounds(Some(-20), -10, -5, Some(3));
     let extended_val = val.cast(CastOpType::IntSExt, ByteSize::new(8));
@@ -508,6 +508,10 @@ fn add_not_equal_bounds() {
     let interval = IntervalDomain::mock(5, 6);
     let x = interval.add_not_equal_bound(&Bitvector::from_i64(5));
     assert_eq!(x.unwrap(), IntervalDomain::mock(6, 6));
+
+    let interval = IntervalDomain::mock_with_bounds(None, 5, 6, Some(100));
+    let x = interval.add_not_equal_bound(&Bitvector::from_i64(10));
+    assert_eq!(x.unwrap(), IntervalDomain::mock_with_bounds(None, 5, 6, Some(9)));
 }
 
 #[test]
@@ -520,4 +524,12 @@ fn intersection() {
         IntervalDomain::mock_with_bounds(Some(-20), 2, 10, Some(100))
     );
     assert!(interval1.intersect(&IntervalDomain::mock(50, 55)).is_err());
+}
+
+#[test]
+fn fits_into_size() {
+    let interval = IntervalDomain::mock_with_bounds(Some(-300), -10, 10, Some(100));
+    assert!(interval.fits_into_size(ByteSize::new(1)));
+    let interval = IntervalDomain::mock_with_bounds(Some(-300), -128, 128, None);
+    assert!(!interval.fits_into_size(ByteSize::new(1)));
 }

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/state/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/state/mod.rs
@@ -385,7 +385,23 @@ impl State {
                     description: _,
                     size: _,
                 } => Ok(()),
-                Expression::Subpiece { .. } => Ok(()),
+                Expression::Subpiece {
+                    low_byte,
+                    size,
+                    arg,
+                } => {
+                    if *low_byte == ByteSize::new(0) {
+                        if let Data::Value(arg_value) = self.eval(expression) {
+                            if arg_value.fits_into_size(*size) {
+                                let intermediate_result =
+                                    result.cast(CastOpType::IntSExt, arg.bytesize());
+                                return self
+                                    .specialize_by_expression_result(arg, intermediate_result);
+                            }
+                        }
+                    }
+                    Ok(())
+                }
             }
         } else {
             Ok(())

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
@@ -542,6 +542,30 @@ fn specialize_by_expression_results() {
         state.get_register(&eax_register),
         Bitvector::from_i32(-7).into()
     );
+
+    // Expr = Subpiece(Var(RAX))
+    let mut state = State::new(&register("RSP"), Tid::new("func_tid"));
+    let rax_register = Variable {
+        name: "RAX".to_string(),
+        size: ByteSize::new(8),
+        is_temp: false,
+    };
+    let x = state.specialize_by_expression_result(
+        &Expression::Var(rax_register.clone()).subpiece(ByteSize::new(0), ByteSize::new(1)),
+        Bitvector::from_i8(5).into(),
+    );
+    assert!(x.is_ok());
+    assert!(state.get_register(&rax_register).is_top());
+    state.set_register(&rax_register, IntervalDomain::mock(3, 10).into());
+    let x = state.specialize_by_expression_result(
+        &Expression::Var(rax_register.clone()).subpiece(ByteSize::new(0), ByteSize::new(1)),
+        Bitvector::from_i8(5).into(),
+    );
+    assert!(x.is_ok());
+    assert_eq!(
+        state.get_register(&rax_register),
+        IntervalDomain::mock(5, 5).into()
+    );
 }
 
 /// Test expression specialization for binary operations


### PR DESCRIPTION
Add a widening delay to the widening strategy to prevent unnecessary widenings. Also fixes some bugs related to the generation of bound hints.