### PR TITLE
fix address size of implicit stores

### DIFF
--- a/src/cwe_checker_lib/src/pcode/expressions.rs
+++ b/src/cwe_checker_lib/src/pcode/expressions.rs
@@ -41,21 +41,41 @@ impl From<Variable> for IrExpression {
     fn from(pcode_var: Variable) -> IrExpression {
         match (&pcode_var.name, &pcode_var.value) {
             (Some(_name), None) => IrExpression::Var(pcode_var.into()),
-            (None, Some(_hex_value)) => IrExpression::Const(pcode_var.parse_to_bitvector()),
+            (None, Some(_hex_value)) => IrExpression::Const(pcode_var.parse_const_to_bitvector()),
             _ => panic!("Conversion failed:\n{:?}", pcode_var),
         }
     }
 }
 
 impl Variable {
-    /// Parses a variable representing a concrete value or a concrete address to a bitvector containing the value or address.
-    pub fn parse_to_bitvector(&self) -> Bitvector {
-        match (&self.value, &self.address) {
-            (Some(hex_value), None) | (None, Some(hex_value)) => {
+    /// Parses a variable representing a concrete value to a bitvector containing the value.
+    pub fn parse_const_to_bitvector(&self) -> Bitvector {
+        match &self.value {
+            Some(hex_value) => {
                 let mut bitvector = Bitvector::from_str_radix(16, hex_value).unwrap();
                 match bitvector.width().cmp(&self.size.into()) {
                     std::cmp::Ordering::Greater => bitvector.truncate(self.size).unwrap(),
                     std::cmp::Ordering::Less => bitvector.zero_extend(self.size).unwrap(),
+                    std::cmp::Ordering::Equal => (),
+                }
+                bitvector
+            }
+            _ => panic!(),
+        }
+    }
+
+    /// Parses a variable representing an address to a pointer-sized bitvector containing the address.
+    pub fn parse_address_to_bitvector(&self, generic_pointer_size: ByteSize) -> Bitvector {
+        match &self.address {
+            Some(hex_value) => {
+                let mut bitvector = Bitvector::from_str_radix(16, hex_value).unwrap();
+                match bitvector.width().cmp(&generic_pointer_size.into()) {
+                    std::cmp::Ordering::Greater => {
+                        bitvector.truncate(generic_pointer_size).unwrap()
+                    }
+                    std::cmp::Ordering::Less => {
+                        bitvector.zero_extend(generic_pointer_size).unwrap()
+                    }
                     std::cmp::Ordering::Equal => (),
                 }
                 bitvector
@@ -415,24 +435,36 @@ mod tests {
             size: ByteSize::new(8),
             is_virtual: false,
         };
-        assert_eq!(var.parse_to_bitvector(), Bitvector::from_u64(0));
+        assert_eq!(var.parse_const_to_bitvector(), Bitvector::from_u64(0));
         var.value = Some("0010f".to_string());
-        assert_eq!(var.parse_to_bitvector(), Bitvector::from_u64(271));
+        assert_eq!(var.parse_const_to_bitvector(), Bitvector::from_u64(271));
         var.value = Some("1ff".to_string());
         var.size = ByteSize::new(1);
-        assert_eq!(var.parse_to_bitvector(), Bitvector::from_u8(255));
+        assert_eq!(var.parse_const_to_bitvector(), Bitvector::from_u8(255));
         var.size = ByteSize::new(16);
-        assert_eq!(var.parse_to_bitvector(), Bitvector::from_u128(511));
+        assert_eq!(var.parse_const_to_bitvector(), Bitvector::from_u128(511));
 
         var.value = Some("00_ffffffffffffffff_ffffffffffffffff".to_string());
         var.size = ByteSize::new(16);
-        assert_eq!(var.parse_to_bitvector(), Bitvector::from_i128(-1));
+        assert_eq!(var.parse_const_to_bitvector(), Bitvector::from_i128(-1));
         var.size = ByteSize::new(10);
         assert_eq!(
-            var.parse_to_bitvector(),
+            var.parse_const_to_bitvector(),
             Bitvector::from_i128(-1)
                 .into_truncate(ByteSize::new(10))
                 .unwrap()
+        );
+
+        let var = Variable {
+            name: None,
+            value: None,
+            address: Some("000010f".to_string()),
+            size: ByteSize::new(1), // Note that this size is not the size of a pointer!
+            is_virtual: false,
+        };
+        assert_eq!(
+            var.parse_address_to_bitvector(ByteSize::new(8)),
+            Bitvector::from_u64(271)
         );
     }
 }

--- a/src/cwe_checker_lib/src/pcode/term/tests.rs
+++ b/src/cwe_checker_lib/src/pcode/term/tests.rs
@@ -396,7 +396,7 @@ fn def_deserialization() {
       "#,
     )
     .unwrap();
-    let _: IrDef = def.into();
+    let _: IrDef = def.into_ir_def(ByteSize::new(8));
     let def: Def = serde_json::from_str(
         r#"
             {
@@ -422,7 +422,7 @@ fn def_deserialization() {
             "#,
     )
     .unwrap();
-    let _: IrDef = def.into();
+    let _: IrDef = def.into_ir_def(ByteSize::new(8));
 }
 
 #[test]
@@ -463,7 +463,7 @@ fn jmp_deserialization() {
 fn blk_deserialization() {
     let setup = Setup::new();
     let block_term: Term<Blk> = setup.blk_t.clone();
-    let _: IrBlk = block_term.term.into();
+    let _: IrBlk = block_term.term.into_ir_blk(ByteSize::new(8));
 }
 
 #[test]
@@ -503,7 +503,7 @@ fn arg_deserialization() {
 fn sub_deserialization() {
     let setup = Setup::new();
     let sub_term: Term<Sub> = setup.sub_t.clone();
-    let _: Term<IrSub> = sub_term.into();
+    let _: Term<IrSub> = sub_term.into_ir_sub_term(ByteSize::new(8));
     let sub_term: Term<Sub> = serde_json::from_str(
         r#"
           {
@@ -542,7 +542,7 @@ fn sub_deserialization() {
     .unwrap();
     // Example has special case where the starting block has to be corrected
     assert!(sub_term.tid.address != sub_term.term.blocks[0].tid.address);
-    let ir_sub: Term<IrSub> = sub_term.into();
+    let ir_sub: Term<IrSub> = sub_term.into_ir_sub_term(ByteSize::new(8));
     assert_eq!(ir_sub.tid.address, ir_sub.term.blocks[0].tid.address);
 }
 
@@ -608,7 +608,7 @@ fn program_deserialization() {
             "#,
     )
     .unwrap();
-    let _: IrProgram = program_term.term.into_ir_program(10000);
+    let _: IrProgram = program_term.term.into_ir_program(10000, ByteSize::new(8));
 }
 
 #[test]


### PR DESCRIPTION
Fixes a bug, where the address size of store instructions was in some cases incorrectly truncated to the byte size of the value to be stored.