### PR TITLE
- Fixed issue #169

### DIFF
--- a/src/ghidra/p_code_extractor/PcodeExtractor.java
+++ b/src/ghidra/p_code_extractor/PcodeExtractor.java
@@ -214,11 +214,16 @@ public class PcodeExtractor extends GhidraScript {
      */
     protected Boolean iteratePcode() {
         int numberOfPcodeOps = PcodeBlockData.ops.length;
+        int previousPcodeIndex = 0;
         Boolean intraInstructionJumpOccured = false;
         PcodeBlockData.pcodeIndex = 0;
         for(PcodeOp op : PcodeBlockData.ops) {
             PcodeBlockData.pcodeOp = op;
             String mnemonic = PcodeBlockData.pcodeOp.getMnemonic();
+            if (previousPcodeIndex < PcodeBlockData.pcodeIndex -1) {
+                numberOfPcodeOps++;
+            }
+            previousPcodeIndex = PcodeBlockData.pcodeIndex;
             if (JumpProcessing.jumps.contains(mnemonic) || PcodeBlockData.pcodeOp.getOpcode() == PcodeOp.UNIMPLEMENTED) {
                 intraInstructionJumpOccured = JumpProcessing.processJump(mnemonic, numberOfPcodeOps);
             } else {

--- a/src/ghidra/p_code_extractor/internal/JumpProcessing.java
+++ b/src/ghidra/p_code_extractor/internal/JumpProcessing.java
@@ -45,7 +45,7 @@ public final class JumpProcessing {
             return processJumpInPcodeBlock(mnemonic, numberOfPcodeOps, currentBlock);
         }
 
-        processJumpAtEndOfPcodeBlocks(mnemonic, numberOfPcodeOps, currentBlock);
+        processJumpAtEndOfPcodeBlocks(mnemonic, currentBlock);
         return false;
     }
 
@@ -53,13 +53,12 @@ public final class JumpProcessing {
     /**
      * 
      * @param mnemonic: pcode mnemonic
-     * @param numberOfPcodeOps: number of pcode instruction in pcode block
      * @param currentBlock: current block term
      * 
      * Process jumps at the end of pcode blocks
      * If it is a return block, the call return address is changed to the current block
      */
-    private static void processJumpAtEndOfPcodeBlocks(String mnemonic, int numberOfPcodeOps, Term<Blk> currentBlock) {
+    private static void processJumpAtEndOfPcodeBlocks(String mnemonic, Term<Blk> currentBlock) {
         // Case 1: jump at the end of pcode group but not end of ghidra generated block. Create a block for the next assembly instruction.
         if(PcodeBlockData.instructionIndex < PcodeBlockData.numberOfInstructionsInBlock - 1 && PcodeBlockData.instruction.getDelaySlotDepth() == 0) {
             PcodeBlockData.blocks.add(TermCreator.createBlkTerm(PcodeBlockData.instruction.getFallThrough().toString(), null));

--- a/src/ghidra/p_code_extractor/internal/TermCreator.java
+++ b/src/ghidra/p_code_extractor/internal/TermCreator.java
@@ -348,7 +348,11 @@ public class TermCreator {
             callString = "unimplemented";
             call = new Call(null, createLabel(PcodeBlockData.instruction.getFallThrough()), callString);
         } else {
-            call = new Call(createLabel(null), createLabel(PcodeBlockData.instruction.getFallThrough()));
+            if (PcodeBlockData.instruction.getFallThrough() == null) {
+                call = new Call(createLabel(null));
+            } else {
+                call = new Call(createLabel(null), createLabel(PcodeBlockData.instruction.getFallThrough()));
+            }
         }
 
         return call;    


### PR DESCRIPTION
- Fixed issue #169 by checking whether the Call has a fallThrough address. Now no Return value is given to the Call.
- Fixed bug where call return pairs were not properly handled when branch instructions were added to the pcode instructions.
  * Adding the branch instruction caused the running pcode index to increase but not the number of pcode instructions which
    needs to be correct for the CallReturn Handler to be triggered.
- Removed dead parameter from jump processing function.