### PR TITLE
Fix bug in sub register handling

### DIFF
--- a/src/cwe_checker_lib/src/intermediate_representation/expression.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/expression.rs
@@ -368,8 +368,19 @@ impl Expression {
             is_temp: false,
         }));
 
-        // Build PIECE as PIECE(lhs:PIECE(lhs:higher subpiece, rhs:sub register), rhs:lower subpiece)
-        if sub_register.lsb > ByteSize::new(0) {
+        if sub_register.lsb > ByteSize::new(0) && sub_register.lsb + sub_register.size == base_size {
+            // Build PIECE as PIECE(lhs: sub_register, rhs: low subpiece)
+            *self = Expression::BinOp {
+                op: BinOpType::Piece,
+                lhs: Box::new(self.clone()),
+                rhs: Box::new(Expression::Subpiece {
+                    low_byte: ByteSize::new(0),
+                    size: sub_lsb,
+                    arg: base_subpiece,
+                }),
+            }
+        } else if sub_register.lsb > ByteSize::new(0) {
+            // Build PIECE as PIECE(lhs:PIECE(lhs:higher subpiece, rhs:sub register), rhs:lower subpiece)
             *self = Expression::BinOp {
                 op: BinOpType::Piece,
                 lhs: Box::new(Expression::BinOp {
@@ -387,9 +398,8 @@ impl Expression {
                     arg: base_subpiece,
                 }),
             }
-        }
-        // Build PIECE as PIECE(lhs: high subpiece, rhs: sub register)
-        else {
+        } else {
+            // Build PIECE as PIECE(lhs: high subpiece, rhs: sub register)
             *self = Expression::BinOp {
                 op: BinOpType::Piece,
                 lhs: Box::new(Expression::Subpiece {

--- a/src/cwe_checker_lib/src/intermediate_representation/expression.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/expression.rs
@@ -368,7 +368,8 @@ impl Expression {
             is_temp: false,
         }));
 
-        if sub_register.lsb > ByteSize::new(0) && sub_register.lsb + sub_register.size == base_size {
+        if sub_register.lsb > ByteSize::new(0) && sub_register.lsb + sub_register.size == base_size
+        {
             // Build PIECE as PIECE(lhs: sub_register, rhs: low subpiece)
             *self = Expression::BinOp {
                 op: BinOpType::Piece,

--- a/src/cwe_checker_lib/src/intermediate_representation/expression/tests.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/expression/tests.rs
@@ -208,6 +208,26 @@ fn piecing_expressions_together() {
         .piece_two_expressions_together(&setup.rax_register, &setup.higher_byte_register);
     assert_eq!(expr, expected_expr);
     assert_eq!(higher_byte_exp, expected_higher_byte_expr);
+
+    let higher_half_rax = RegisterProperties {
+        register: "upper_RAX_half".to_string(),
+        base_register: "RAX".to_string(),
+        lsb: ByteSize::new(4),
+        size: ByteSize::new(4),
+    };
+    let mut expression = Expression::Const(Bitvector::from_u32(42));
+
+    let expected_output = Expression::BinOp {
+        op: BinOpType::Piece,
+        lhs: Box::new(expression.clone()),
+        rhs: Box::new(Expression::Subpiece {
+            low_byte: ByteSize(0),
+            size: ByteSize::new(4),
+            arg: Box::new(setup.rax_variable.clone()),
+        })
+    };
+    expression.piece_two_expressions_together(&setup.rax_register, &higher_half_rax);
+    assert_eq!(expression, expected_output);
 }
 
 #[test]

--- a/src/cwe_checker_lib/src/intermediate_representation/expression/tests.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/expression/tests.rs
@@ -224,7 +224,7 @@ fn piecing_expressions_together() {
             low_byte: ByteSize(0),
             size: ByteSize::new(4),
             arg: Box::new(setup.rax_variable.clone()),
-        })
+        }),
     };
     expression.piece_two_expressions_together(&setup.rax_register, &higher_half_rax);
     assert_eq!(expression, expected_output);

--- a/src/ghidra/p_code_extractor/internal/HelperFunctions.java
+++ b/src/ghidra/p_code_extractor/internal/HelperFunctions.java
@@ -235,12 +235,11 @@ public final class HelperFunctions {
     public static ArrayList<RegisterProperties> getRegisterList() {
         ArrayList<RegisterProperties> regProps = new ArrayList<RegisterProperties>();
         Language language = ghidraProgram.getLanguage();
-        int archSizeInBytes = (int)(language.getLanguageDescription().getSize() / 8);
         for(Register reg : language.getRegisters()) {
             regProps.add(
                 new RegisterProperties(reg.getName(), 
                                        reg.getBaseRegister().getName(), 
-                                       (int)(reg.getLeastSignificatBitInBaseRegister() / archSizeInBytes),
+                                       (int)(reg.getLeastSignificatBitInBaseRegister() / 8),
                                        context.getRegisterVarnode(reg).getSize())
             );
         }


### PR DESCRIPTION
- The position of sub registers in the base register was sometimes incorrect for 32bit architectures.
- A special case for sub register handling was missing.