### PR TITLE
deny missing docs in the CI

### DIFF
--- a/.github/workflows/codestyle_checks.yml
+++ b/.github/workflows/codestyle_checks.yml
@@ -36,4 +36,4 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D clippy::all
+          args: -- -D clippy::all -D missing_docs


### PR DESCRIPTION
Missing documentation warnings were already handled as errors when manually running code style checks. Now the CI also handles these as errors.