### PR TITLE
Error Handling for Parameter Parsing

### DIFF
--- a/src/cwe_checker_lib/src/checkers/cwe_78/context/parameter_detection.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/context/parameter_detection.rs
@@ -103,7 +103,7 @@ impl<'a> Context<'a> {
                     }
                 }
             }
-            // TODO: Log errors that came up during the parameter parsing. 
+            // TODO: Log errors that came up during the parameter parsing.
         }
         new_state
     }

--- a/src/cwe_checker_lib/src/checkers/cwe_78/context/parameter_detection.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/context/parameter_detection.rs
@@ -74,30 +74,36 @@ impl<'a> Context<'a> {
             .pointer_inference_results
             .get_node_value(call_source_node)
         {
-            let parameters = arguments::get_variable_number_parameters(
+            if let Ok(parameters) = arguments::get_variable_number_parameters(
                 self.project,
                 pi_state,
                 user_input_symbol,
                 &self.symbol_maps.format_string_index,
                 self.runtime_memory_image,
-            );
-            if !parameters.is_empty() {
-                match user_input_symbol.name.as_str() {
-                    "scanf" | "__isoc99_scanf" => {
-                        self.process_scanf(call_source_node, &mut new_state, pi_state, parameters)
-                    }
-                    "sscanf" | "__isoc99_sscanf" => {
-                        let source_string_register = user_input_symbol.parameters.get(0).unwrap();
-                        self.process_sscanf(
+            ) {
+                if !parameters.is_empty() {
+                    match user_input_symbol.name.as_str() {
+                        "scanf" | "__isoc99_scanf" => self.process_scanf(
+                            call_source_node,
                             &mut new_state,
                             pi_state,
                             parameters,
-                            source_string_register,
-                        )
+                        ),
+                        "sscanf" | "__isoc99_sscanf" => {
+                            let source_string_register =
+                                user_input_symbol.parameters.get(0).unwrap();
+                            self.process_sscanf(
+                                &mut new_state,
+                                pi_state,
+                                parameters,
+                                source_string_register,
+                            )
+                        }
+                        _ => panic!("Invalid user input symbol."),
                     }
-                    _ => panic!("Invalid user input symbol."),
                 }
             }
+            // TODO: Log errors that came up during the parameter parsing. 
         }
         new_state
     }
@@ -222,13 +228,18 @@ impl<'a> Context<'a> {
             if self.is_relevant_string_function_call(string_symbol, pi_state, &mut new_state) {
                 let mut parameters = string_symbol.parameters.clone();
                 if string_symbol.has_var_args {
-                    parameters = arguments::get_variable_number_parameters(
+                    if let Ok(args) = arguments::get_variable_number_parameters(
                         self.project,
                         pi_state,
                         string_symbol,
                         &self.symbol_maps.format_string_index,
                         self.runtime_memory_image,
-                    );
+                    ) {
+                        parameters = args;
+                    } else {
+                        // TODO: Log errors that came up during the parameter parsing.
+                        parameters = vec![]
+                    }
                 }
                 self.taint_function_parameters(&mut new_state, pi_state, parameters);
             }

--- a/src/cwe_checker_lib/src/utils/arguments/tests.rs
+++ b/src/cwe_checker_lib/src/utils/arguments/tests.rs
@@ -43,6 +43,7 @@ fn test_get_variable_number_parameters() {
             &format_string_index_map,
             &mem_image,
         )
+        .unwrap()
     );
 
     output.push(Arg::Stack {
@@ -65,6 +66,7 @@ fn test_get_variable_number_parameters() {
             &format_string_index_map,
             &mem_image,
         )
+        .unwrap()
     );
 }
 
@@ -89,6 +91,7 @@ fn test_get_input_format_string() {
             &Variable::mock("RSP", 8 as u64),
             &mem_image
         )
+        .unwrap()
     );
 }
 
@@ -96,14 +99,11 @@ fn test_get_input_format_string() {
 fn test_parse_format_string_destination_and_return_content() {
     let mem_image = RuntimeMemoryImage::mock();
     let string_address_vector = Bitvector::from_str_radix(16, "3002").unwrap();
-    let string_address = DataDomain::Value(IntervalDomain::new(
-        string_address_vector.clone(),
-        string_address_vector,
-    ));
+    let string_address = IntervalDomain::new(string_address_vector.clone(), string_address_vector);
 
     assert_eq!(
         "Hello World",
-        parse_format_string_destination_and_return_content(string_address, &mem_image)
+        parse_format_string_destination_and_return_content(string_address, &mem_image).unwrap()
     );
 }
 


### PR DESCRIPTION
The parameter parsing from format strings now allows the developer to log specific errors rather than crashing the analysis in case a format string was externally provided or certain parameters could not be parsed properly.