### PR TITLE
Mock objects with bytesize

### DIFF
--- a/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
@@ -486,15 +486,17 @@ fn specialize_by_expression_results() {
     // Expr = Var(RAX)
     let mut state = base_state.clone();
     let x = state
-        .specialize_by_expression_result(&Expression::var("RAX"), Bitvector::from_i64(7).into());
+        .specialize_by_expression_result(&Expression::var("RAX", 8), Bitvector::from_i64(7).into());
     assert!(x.is_ok());
     assert_eq!(
         state.get_register(&register("RAX")),
         Bitvector::from_i64(7).into()
     );
     let mut state = base_state.clone();
-    let x = state
-        .specialize_by_expression_result(&Expression::var("RAX"), Bitvector::from_i64(-20).into());
+    let x = state.specialize_by_expression_result(
+        &Expression::var("RAX", 8),
+        Bitvector::from_i64(-20).into(),
+    );
     assert!(x.is_err());
 
     let mut state = base_state.clone();
@@ -507,7 +509,7 @@ fn specialize_by_expression_results() {
         PointerDomain::new(abstract_id.clone(), IntervalDomain::mock(0, 50)).into(),
     );
     let x = state.specialize_by_expression_result(
-        &Expression::var("RAX"),
+        &Expression::var("RAX", 8),
         PointerDomain::new(abstract_id.clone(), IntervalDomain::mock(20, 70)).into(),
     );
     assert!(x.is_ok());
@@ -533,7 +535,7 @@ fn specialize_by_expression_results() {
     // Expr = -Var(RAX)
     let mut state = base_state.clone();
     let x = state.specialize_by_expression_result(
-        &Expression::var("RAX").un_op(UnOpType::Int2Comp),
+        &Expression::var("RAX", 8).un_op(UnOpType::Int2Comp),
         Bitvector::from_i64(-7).into(),
     );
     assert!(x.is_ok());
@@ -597,7 +599,7 @@ fn specialize_by_binop() {
     // Expr = RAX + Const
     let mut state = base_state.clone();
     let x = state.specialize_by_expression_result(
-        &Expression::var("RAX").plus_const(20),
+        &Expression::var("RAX", 8).plus_const(20),
         IntervalDomain::mock(5, 7).into(),
     );
     assert!(x.is_ok());
@@ -609,7 +611,7 @@ fn specialize_by_binop() {
     // Expr = RAX - Const
     let mut state = base_state.clone();
     let x = state.specialize_by_expression_result(
-        &Expression::var("RAX").minus_const(20),
+        &Expression::var("RAX", 8).minus_const(20),
         Bitvector::from_i64(5).into(),
     );
     assert!(x.is_ok());
@@ -622,7 +624,7 @@ fn specialize_by_binop() {
     let mut state = base_state.clone();
     let x = state.specialize_by_expression_result(
         &Expression::BinOp {
-            lhs: Box::new(Expression::var("RAX")),
+            lhs: Box::new(Expression::var("RAX", 8)),
             op: BinOpType::IntXOr,
             rhs: Box::new(Expression::const_from_i64(3)),
         },
@@ -638,9 +640,9 @@ fn specialize_by_binop() {
     let mut state = base_state.clone();
     let x = state.specialize_by_expression_result(
         &Expression::BinOp {
-            lhs: Box::new(Expression::var("RAX")),
+            lhs: Box::new(Expression::var("RAX", 8)),
             op: BinOpType::IntOr,
-            rhs: Box::new(Expression::var("RBX")),
+            rhs: Box::new(Expression::var("RBX", 8)),
         },
         Bitvector::from_i64(0).into(),
     );
@@ -657,7 +659,7 @@ fn specialize_by_binop() {
     let mut state = base_state.clone();
     let x = state.specialize_by_expression_result(
         &Expression::BinOp {
-            lhs: Box::new(Expression::var("RAX")),
+            lhs: Box::new(Expression::var("RAX", 8)),
             op: BinOpType::IntOr,
             rhs: Box::new(Expression::const_from_i64(0)),
         },
@@ -717,7 +719,7 @@ fn specialize_by_equality_comparison() {
         &Expression::BinOp {
             lhs: Box::new(Expression::const_from_i64(23)),
             op: BinOpType::IntEqual,
-            rhs: Box::new(Expression::var("RAX")),
+            rhs: Box::new(Expression::var("RAX", 8)),
         },
         Bitvector::from_u8(1).into(),
     );
@@ -731,7 +733,7 @@ fn specialize_by_equality_comparison() {
         &Expression::BinOp {
             lhs: Box::new(Expression::const_from_i64(23)),
             op: BinOpType::IntNotEqual,
-            rhs: Box::new(Expression::var("RAX")),
+            rhs: Box::new(Expression::var("RAX", 8)),
         },
         Bitvector::from_u8(0).into(),
     );
@@ -748,7 +750,7 @@ fn specialize_by_equality_comparison() {
         &Expression::BinOp {
             lhs: Box::new(Expression::const_from_i64(23)),
             op: BinOpType::IntNotEqual,
-            rhs: Box::new(Expression::var("RAX")),
+            rhs: Box::new(Expression::var("RAX", 8)),
         },
         Bitvector::from_u8(1).into(),
     );
@@ -758,7 +760,7 @@ fn specialize_by_equality_comparison() {
         &Expression::BinOp {
             lhs: Box::new(Expression::const_from_i64(100)),
             op: BinOpType::IntEqual,
-            rhs: Box::new(Expression::var("RAX")),
+            rhs: Box::new(Expression::var("RAX", 8)),
         },
         Bitvector::from_u8(0).into(),
     );

--- a/src/cwe_checker_lib/src/checkers/cwe_134.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_134.rs
@@ -196,7 +196,7 @@ pub mod tests {
         let def1 = Def::assign(
             "def2",
             Variable::mock("RDI", 8 as u64),
-            Expression::var("RBP").plus_const(8),
+            Expression::var("RBP", 8).plus_const(8),
         );
         let def2 = Def::assign(
             "def3",

--- a/src/cwe_checker_lib/src/checkers/cwe_78/context/parameter_detection.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/context/parameter_detection.rs
@@ -103,7 +103,7 @@ impl<'a> Context<'a> {
                     }
                 }
             }
-            // TODO: Log errors that came up during the parameter parsing. 
+            // TODO: Log errors that came up during the parameter parsing.
         }
         new_state
     }

--- a/src/cwe_checker_lib/src/checkers/cwe_78/context/parameter_detection.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/context/parameter_detection.rs
@@ -74,30 +74,36 @@ impl<'a> Context<'a> {
             .pointer_inference_results
             .get_node_value(call_source_node)
         {
-            let parameters = arguments::get_variable_number_parameters(
+            if let Ok(parameters) = arguments::get_variable_number_parameters(
                 self.project,
                 pi_state,
                 user_input_symbol,
                 &self.symbol_maps.format_string_index,
                 self.runtime_memory_image,
-            );
-            if !parameters.is_empty() {
-                match user_input_symbol.name.as_str() {
-                    "scanf" | "__isoc99_scanf" => {
-                        self.process_scanf(call_source_node, &mut new_state, pi_state, parameters)
-                    }
-                    "sscanf" | "__isoc99_sscanf" => {
-                        let source_string_register = user_input_symbol.parameters.get(0).unwrap();
-                        self.process_sscanf(
+            ) {
+                if !parameters.is_empty() {
+                    match user_input_symbol.name.as_str() {
+                        "scanf" | "__isoc99_scanf" => self.process_scanf(
+                            call_source_node,
                             &mut new_state,
                             pi_state,
                             parameters,
-                            source_string_register,
-                        )
+                        ),
+                        "sscanf" | "__isoc99_sscanf" => {
+                            let source_string_register =
+                                user_input_symbol.parameters.get(0).unwrap();
+                            self.process_sscanf(
+                                &mut new_state,
+                                pi_state,
+                                parameters,
+                                source_string_register,
+                            )
+                        }
+                        _ => panic!("Invalid user input symbol."),
                     }
-                    _ => panic!("Invalid user input symbol."),
                 }
             }
+            // TODO: Log errors that came up during the parameter parsing. 
         }
         new_state
     }
@@ -222,13 +228,18 @@ impl<'a> Context<'a> {
             if self.is_relevant_string_function_call(string_symbol, pi_state, &mut new_state) {
                 let mut parameters = string_symbol.parameters.clone();
                 if string_symbol.has_var_args {
-                    parameters = arguments::get_variable_number_parameters(
+                    if let Ok(args) = arguments::get_variable_number_parameters(
                         self.project,
                         pi_state,
                         string_symbol,
                         &self.symbol_maps.format_string_index,
                         self.runtime_memory_image,
-                    );
+                    ) {
+                        parameters = args;
+                    } else {
+                        // TODO: Log errors that came up during the parameter parsing.
+                        parameters = vec![]
+                    }
                 }
                 self.taint_function_parameters(&mut new_state, pi_state, parameters);
             }

--- a/src/cwe_checker_lib/src/checkers/cwe_78/context/tests.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/context/tests.rs
@@ -20,8 +20,8 @@ impl ExternSymbol {
             addresses: vec!["UNKNOWN".to_string()],
             name: "sprintf".to_string(),
             calling_convention: Some("__stdcall".to_string()),
-            parameters: vec![Arg::mock_register("RDI"), Arg::mock_register("RSI")],
-            return_values: vec![Arg::mock_register("RAX")],
+            parameters: vec![Arg::mock_register("RDI", 8), Arg::mock_register("RSI", 8)],
+            return_values: vec![Arg::mock_register("RAX", 8)],
             no_return: false,
             has_var_args: true,
         }
@@ -33,8 +33,8 @@ impl ExternSymbol {
             addresses: vec!["UNKNOWN".to_string()],
             name: "scanf".to_string(),
             calling_convention: Some("__stdcall".to_string()),
-            parameters: vec![Arg::mock_register("RDI")],
-            return_values: vec![Arg::mock_register("RAX")],
+            parameters: vec![Arg::mock_register("RDI", 8)],
+            return_values: vec![Arg::mock_register("RAX", 8)],
             no_return: false,
             has_var_args: true,
         }
@@ -46,8 +46,8 @@ impl ExternSymbol {
             addresses: vec!["UNKNOWN".to_string()],
             name: "sscanf".to_string(),
             calling_convention: Some("__stdcall".to_string()),
-            parameters: vec![Arg::mock_register("RDI"), Arg::mock_register("RSI")],
-            return_values: vec![Arg::mock_register("RAX")],
+            parameters: vec![Arg::mock_register("RDI", 8), Arg::mock_register("RSI", 8)],
+            return_values: vec![Arg::mock_register("RAX", 8)],
             no_return: false,
             has_var_args: true,
         }
@@ -80,12 +80,12 @@ impl Setup {
         let def1 = Def::assign(
             "def1",
             Variable::mock("RBP", 8 as u64),
-            Expression::var("RSP"),
+            Expression::var("RSP", 8),
         );
         let def2 = Def::assign(
             "def2",
             Variable::mock("RDI", 8 as u64),
-            Expression::var("RBP").plus_const(-8),
+            Expression::var("RBP", 8).plus_const(-8),
         );
         let def3 = Def::assign(
             "def3",
@@ -348,12 +348,12 @@ fn getting_blk_start_node_if_last_def() {
     let def1 = Def::assign(
         "def1",
         Variable::mock("RBP", 8 as u64),
-        Expression::var("RSP"),
+        Expression::var("RSP", 8),
     );
     let def2 = Def::assign(
         "def2",
         Variable::mock("RDI", 8 as u64),
-        Expression::var("RBP").plus_const(-8),
+        Expression::var("RBP", 8).plus_const(-8),
     );
 
     let def3 = Def::assign(
@@ -507,17 +507,17 @@ fn handling_assign_and_load() {
     let mock_assign_register = Def::assign(
         "assign",
         Variable::mock("R9", 8 as u64),
-        Expression::var("RDI"),
+        Expression::var("RDI", 8),
     );
     let mock_assign_stack = Def::assign(
         "stack_assign",
         Variable::mock("R9", 8 as u64),
-        Expression::var("RSP"),
+        Expression::var("RSP", 8),
     );
     let mock_load = Def::load(
         "load",
         Variable::mock("R9", 8 as u64),
-        Expression::var("RDI"),
+        Expression::var("RDI", 8),
     );
     let mut pi_map: HashMap<Tid, PointerInferenceState> = HashMap::new();
 
@@ -590,19 +590,19 @@ fn updating_def() {
     let mock_assign_register = Def::assign(
         "assign",
         Variable::mock("R9", 8 as u64),
-        Expression::var("RDI"),
+        Expression::var("RDI", 8),
     );
     let mock_assign_stack = Def::assign(
         "stack_assign",
         Variable::mock("R9", 8 as u64),
-        Expression::var("RSP"),
+        Expression::var("RSP", 8),
     );
     let mock_load = Def::load(
         "load",
         Variable::mock("R9", 8 as u64),
-        Expression::var("RDI"),
+        Expression::var("RDI", 8),
     );
-    let mock_store = Def::store("store", Expression::var("R9"), Expression::var("RDI"));
+    let mock_store = Def::store("store", Expression::var("R9", 8), Expression::var("RDI", 8));
     let mut pi_map: HashMap<Tid, PointerInferenceState> = HashMap::new();
 
     let stack_id = setup.pi_state.stack_id.clone();

--- a/src/cwe_checker_lib/src/checkers/cwe_78/state/tests.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/state/tests.rs
@@ -134,7 +134,7 @@ fn setting_expression_and_constants() {
     );
 
     // Test Case 2: Variables
-    let copy_var_expr = Expression::var("RSI");
+    let copy_var_expr = Expression::var("RSI", 8);
     setup
         .state
         .set_register_taint(&setup.rdi, Taint::Tainted(setup.rdi.size));
@@ -153,7 +153,7 @@ fn setting_expression_and_constants() {
     );
 
     // Test Case 2.5: Stack Pointer Assignment
-    let stack_expression = Expression::var("RSP");
+    let stack_expression = Expression::var("RSP", 8);
     setup
         .state
         .set_register_taint(&setup.rdi, Taint::Tainted(setup.rdi.size));
@@ -173,7 +173,7 @@ fn setting_expression_and_constants() {
     );
 
     // Test Case 3: Bin Ops
-    let bin_op_expr = Expression::var("RBP").plus_const(-8);
+    let bin_op_expr = Expression::var("RBP", 8).plus_const(-8);
     setup
         .state
         .set_register_taint(&setup.rdi, Taint::Tainted(setup.rdi.size));
@@ -194,7 +194,7 @@ fn setting_expression_and_constants() {
     );
 
     // Test Case 4: Any other Expression
-    let cast_expr = Expression::var("RDI")
+    let cast_expr = Expression::var("RDI", 8)
         .subpiece(ByteSize::new(0), ByteSize::new(4))
         .cast(CastOpType::IntZExt);
 
@@ -231,8 +231,8 @@ fn tainting_values_to_be_stored() {
         .save_taint_to_memory(&setup.base_eight_offset, Taint::Tainted(ByteSize::new(8)));
     setup.state.taint_value_to_be_stored(
         &setup.def_tid,
-        &Expression::var("RDI"),
-        &Expression::var("RSI"),
+        &Expression::var("RDI", 8),
+        &Expression::var("RSI", 8),
         &stack_pointer,
         &RuntimeMemoryImage::mock(),
     );
@@ -257,8 +257,8 @@ fn tainting_values_to_be_stored() {
         .set_pointer_inference_state_for_def(Some(setup.pi_state.clone()), &setup.def_tid);
     setup.state.taint_value_to_be_stored(
         &setup.def_tid,
-        &Expression::var("RDI"),
-        &Expression::var("RSI"),
+        &Expression::var("RDI", 8),
+        &Expression::var("RSI", 8),
         &stack_pointer,
         &RuntimeMemoryImage::mock(),
     );
@@ -277,7 +277,7 @@ fn tainting_def_input_register() {
 
     // Test Case 1: Variable input
     setup.state.taint_def_input_register(
-        &Expression::var("RDI"),
+        &Expression::var("RDI", 8),
         &stack_pointer,
         &setup.def_tid,
         &RuntimeMemoryImage::mock(),
@@ -289,7 +289,7 @@ fn tainting_def_input_register() {
 
     // Test Case 2: Stack Pointer input
     setup.state.taint_def_input_register(
-        &Expression::var("RSP"),
+        &Expression::var("RSP", 8),
         &stack_pointer,
         &setup.def_tid,
         &RuntimeMemoryImage::mock(),
@@ -306,7 +306,7 @@ fn tainting_def_input_register() {
 
     // Test Case 3: Bin Op Input
     setup.state.taint_def_input_register(
-        &Expression::var("RDI").plus_const(8),
+        &Expression::var("RDI", 8).plus_const(8),
         &stack_pointer,
         &setup.def_tid,
         &RuntimeMemoryImage::mock(),
@@ -320,7 +320,7 @@ fn tainting_def_input_register() {
 
     // Test Case 4: Cast Op Input
     setup.state.taint_def_input_register(
-        &Expression::var("RDI").cast(CastOpType::IntZExt),
+        &Expression::var("RDI", 8).cast(CastOpType::IntZExt),
         &stack_pointer,
         &setup.def_tid,
         &RuntimeMemoryImage::mock(),

--- a/src/cwe_checker_lib/src/intermediate_representation/expression/builder.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/expression/builder.rs
@@ -14,6 +14,12 @@ impl Expression {
         Expression::Const(Bitvector::from_i64(value))
     }
 
+    /// Shortcut for creating a constant expression from an i32 value
+    #[cfg(test)]
+    pub fn const_from_i32(value: i32) -> Expression {
+        Expression::Const(Bitvector::from_i32(value))
+    }
+
     /// Shortcut for creating a constant expression from an apint value (e.g. copy of global address)
     #[cfg(test)]
     pub fn const_from_apint(value: ApInt) -> Expression {
@@ -22,10 +28,10 @@ impl Expression {
 
     /// Shortcut for creating a variable expression
     #[cfg(test)]
-    pub fn var(name: &str) -> Expression {
+    pub fn var(name: impl ToString, size_in_bytes: impl Into<ByteSize>) -> Expression {
         Expression::Var(Variable {
-            name: name.into(),
-            size: ByteSize::new(8),
+            name: name.to_string(),
+            size: size_in_bytes.into(),
             is_temp: false,
         })
     }

--- a/src/cwe_checker_lib/src/intermediate_representation/term.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/term.rs
@@ -813,8 +813,8 @@ mod tests {
     }
 
     impl Arg {
-        pub fn mock_register(name: impl ToString) -> Arg {
-            Arg::Register(Variable::mock(name.to_string(), ByteSize::new(8)))
+        pub fn mock_register(name: impl ToString, size_in_bytes: impl Into<ByteSize>) -> Arg {
+            Arg::Register(Variable::mock(name.to_string(), size_in_bytes))
         }
     }
 
@@ -825,8 +825,8 @@ mod tests {
                 addresses: vec!["UNKNOWN".to_string()],
                 name: "mock_symbol".to_string(),
                 calling_convention: Some("__stdcall".to_string()),
-                parameters: vec![Arg::mock_register("RDI")],
-                return_values: vec![Arg::mock_register("RAX")],
+                parameters: vec![Arg::mock_register("RDI", 8)],
+                return_values: vec![Arg::mock_register("RAX", 8)],
                 no_return: false,
                 has_var_args: false,
             }
@@ -977,27 +977,27 @@ mod tests {
             Def::assign(
                 "tid_1",
                 Variable::mock("X", 8),
-                Expression::var("Y").un_op(UnOpType::IntNegate),
+                Expression::var("Y", 8).un_op(UnOpType::IntNegate),
             ),
             Def::assign(
                 "tid_2",
                 Variable::mock("Y", 8),
-                Expression::var("X").plus(Expression::var("Y")),
+                Expression::var("X", 8).plus(Expression::var("Y", 8)),
             ),
             Def::assign(
                 "tid_3",
                 Variable::mock("X", 8),
-                Expression::var("X").un_op(UnOpType::IntNegate),
+                Expression::var("X", 8).un_op(UnOpType::IntNegate),
             ),
             Def::assign(
                 "tid_4",
                 Variable::mock("Y", 8),
-                Expression::var("Y").un_op(UnOpType::IntNegate),
+                Expression::var("Y", 8).un_op(UnOpType::IntNegate),
             ),
             Def::assign(
                 "tid_5",
                 Variable::mock("Y", 8),
-                Expression::var("X").plus(Expression::var("Y")),
+                Expression::var("X", 8).plus(Expression::var("Y", 8)),
             ),
         ];
         let mut block = Term {
@@ -1014,24 +1014,24 @@ mod tests {
             Def::assign(
                 "tid_1",
                 Variable::mock("X", 8),
-                Expression::var("Y").un_op(UnOpType::IntNegate),
+                Expression::var("Y", 8).un_op(UnOpType::IntNegate),
             ),
             Def::assign(
                 "tid_2",
                 Variable::mock("Y", 8),
-                Expression::var("Y")
+                Expression::var("Y", 8)
                     .un_op(UnOpType::IntNegate)
-                    .plus(Expression::var("Y")),
+                    .plus(Expression::var("Y", 8)),
             ),
             Def::assign(
                 "tid_3",
                 Variable::mock("X", 8),
-                Expression::var("X").un_op(UnOpType::IntNegate),
+                Expression::var("X", 8).un_op(UnOpType::IntNegate),
             ),
             Def::assign(
                 "tid_5",
                 Variable::mock("Y", 8),
-                Expression::var("X").plus(Expression::var("Y").un_op(UnOpType::IntNegate)),
+                Expression::var("X", 8).plus(Expression::var("Y", 8).un_op(UnOpType::IntNegate)),
             ),
         ];
         assert_eq!(block.term.defs, result_defs);

--- a/src/cwe_checker_lib/src/utils/arguments/tests.rs
+++ b/src/cwe_checker_lib/src/utils/arguments/tests.rs
@@ -43,6 +43,7 @@ fn test_get_variable_number_parameters() {
             &format_string_index_map,
             &mem_image,
         )
+        .unwrap()
     );
 
     output.push(Arg::Stack {
@@ -65,6 +66,7 @@ fn test_get_variable_number_parameters() {
             &format_string_index_map,
             &mem_image,
         )
+        .unwrap()
     );
 }
 
@@ -89,6 +91,7 @@ fn test_get_input_format_string() {
             &Variable::mock("RSP", 8 as u64),
             &mem_image
         )
+        .unwrap()
     );
 }
 
@@ -96,14 +99,11 @@ fn test_get_input_format_string() {
 fn test_parse_format_string_destination_and_return_content() {
     let mem_image = RuntimeMemoryImage::mock();
     let string_address_vector = Bitvector::from_str_radix(16, "3002").unwrap();
-    let string_address = DataDomain::Value(IntervalDomain::new(
-        string_address_vector.clone(),
-        string_address_vector,
-    ));
+    let string_address = IntervalDomain::new(string_address_vector.clone(), string_address_vector);
 
     assert_eq!(
         "Hello World",
-        parse_format_string_destination_and_return_content(string_address, &mem_image)
+        parse_format_string_destination_and_return_content(string_address, &mem_image).unwrap()
     );
 }
 

--- a/src/cwe_checker_lib/src/utils/binary.rs
+++ b/src/cwe_checker_lib/src/utils/binary.rs
@@ -337,6 +337,30 @@ pub mod tests {
                         write_flag: false,
                         execute_flag: false,
                     },
+                    // Contains string: 'cat %s %s %s %s' starting at the first byte.
+                    MemorySegment {
+                        bytes: [
+                            0x63, 0x61, 0x74, 0x20, 0x25, 0x73, 0x20, 0x25, 0x73, 0x20, 0x25, 0x73,
+                            0x20, 0x25, 0x73, 0x00,
+                        ]
+                        .to_vec(),
+                        base_address: 0x6000,
+                        read_flag: true,
+                        write_flag: false,
+                        execute_flag: false,
+                    },
+                    // Contains string: 'str1 str2 str3 str4'
+                    MemorySegment {
+                        bytes: [
+                            0x73, 0x74, 0x72, 0x31, 0x20, 0x73, 0x74, 0x72, 0x32, 0x20, 0x73, 0x74,
+                            0x72, 0x33, 0x20, 0x73, 0x74, 0x72, 0x34, 0x00,
+                        ]
+                        .to_vec(),
+                        base_address: 0x7000,
+                        read_flag: true,
+                        write_flag: false,
+                        execute_flag: false,
+                    },
                 ],
                 is_little_endian: true,
             }


### PR DESCRIPTION
Mock functions of objects now take a bytesize parameter.
Added two new memory blocks to the memory image mock.