### PR TITLE
better error message on output file write error

### DIFF
--- a/src/cwe_checker_lib/src/utils/log.rs
+++ b/src/cwe_checker_lib/src/utils/log.rs
@@ -189,7 +189,9 @@ pub fn print_all_messages(
             + "\n"
     };
     if let Some(file_path) = out_path {
-        std::fs::write(file_path, output).unwrap();
+        std::fs::write(file_path, output).unwrap_or_else(|error| {
+            panic!("Writing to output path {} failed: {}", file_path, error)
+        });
     } else {
         print!("{}", output);
     }


### PR DESCRIPTION
Fixes an issue raised in #192 where the error message reported to the user does not explain to the user what went wrong.