### PR TITLE
Sort generated CWE warnings by address

### DIFF
--- a/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
@@ -39,7 +39,7 @@ use crate::{
 use petgraph::graph::NodeIndex;
 use petgraph::visit::IntoNodeReferences;
 use petgraph::Direction;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 mod context;
 pub mod object;
@@ -496,9 +496,9 @@ pub fn run<'a>(
 fn collect_all_logs(
     receiver: crossbeam_channel::Receiver<LogThreadMsg>,
 ) -> (Vec<LogMessage>, Vec<CweWarning>) {
-    let mut logs_with_address = HashMap::new();
+    let mut logs_with_address = BTreeMap::new();
     let mut general_logs = Vec::new();
-    let mut collected_cwes = HashMap::new();
+    let mut collected_cwes = BTreeMap::new();
 
     while let Ok(log_thread_msg) = receiver.recv() {
         match log_thread_msg {
@@ -523,7 +523,10 @@ fn collect_all_logs(
         .cloned()
         .chain(general_logs.into_iter())
         .collect();
-    let cwes = collected_cwes.drain().map(|(_key, value)| value).collect();
+    let cwes = collected_cwes
+        .into_iter()
+        .map(|(_key, value)| value)
+        .collect();
     (logs, cwes)
 }
 

--- a/src/cwe_checker_lib/src/checkers/cwe_134.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_134.rs
@@ -107,6 +107,7 @@ pub fn check_cwe(
         }
     }
 
+    cwe_warnings.sort();
     (Vec::new(), cwe_warnings)
 }
 

--- a/src/cwe_checker_lib/src/checkers/cwe_190.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_190.rs
@@ -116,5 +116,6 @@ pub fn check_cwe(
         }
     }
 
+    cwe_warnings.sort();
     (Vec::new(), cwe_warnings)
 }

--- a/src/cwe_checker_lib/src/checkers/cwe_243.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_243.rs
@@ -175,5 +175,6 @@ pub fn check_cwe(
         }
     }
 
+    cwe_warnings.sort();
     (Vec::new(), cwe_warnings)
 }

--- a/src/cwe_checker_lib/src/checkers/cwe_332.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_332.rs
@@ -70,5 +70,6 @@ pub fn check_cwe(
             cwe_warnings.push(generate_cwe_warning(secure_initializer_func, rand_func));
         }
     }
+    cwe_warnings.sort();
     (Vec::new(), cwe_warnings)
 }

--- a/src/cwe_checker_lib/src/checkers/cwe_367.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_367.rs
@@ -119,5 +119,6 @@ pub fn check_cwe(
         }
     }
 
+    cwe_warnings.sort();
     (Vec::new(), cwe_warnings)
 }

--- a/src/cwe_checker_lib/src/checkers/cwe_426.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_426.rs
@@ -96,5 +96,6 @@ pub fn check_cwe(
             }
         }
     }
+    cwe_warnings.sort();
     (Vec::new(), cwe_warnings)
 }

--- a/src/cwe_checker_lib/src/checkers/cwe_467.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_467.rs
@@ -132,5 +132,6 @@ pub fn check_cwe(
             }
         }
     }
+    cwe_warnings.sort();
     (Vec::new(), cwe_warnings)
 }

--- a/src/cwe_checker_lib/src/checkers/cwe_476.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_476.rs
@@ -45,7 +45,7 @@ use crate::prelude::*;
 use crate::utils::log::{CweWarning, LogMessage};
 use crate::CweModule;
 use petgraph::visit::EdgeRef;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 mod state;
 use state::*;
@@ -123,7 +123,7 @@ pub fn check_cwe(
         }
     }
 
-    let mut cwe_warnings = HashMap::new();
+    let mut cwe_warnings = BTreeMap::new();
     for cwe in cwe_receiver.try_iter() {
         match &cwe.addresses[..] {
             [taint_source_address, ..] => cwe_warnings.insert(taint_source_address.clone(), cwe),

--- a/src/cwe_checker_lib/src/checkers/cwe_560.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_560.rs
@@ -141,5 +141,6 @@ pub fn check_cwe(
         }
     }
 
+    cwes.sort();
     (log_messages, cwes)
 }

--- a/src/cwe_checker_lib/src/checkers/cwe_676.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_676.rs
@@ -89,6 +89,7 @@ pub fn generate_cwe_warnings<'a>(
         cwe_warnings.push(cwe_warning);
     }
 
+    cwe_warnings.sort();
     cwe_warnings
 }
 

--- a/src/cwe_checker_lib/src/checkers/cwe_78.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78.rs
@@ -41,7 +41,7 @@
 //! - Missing Taints due to lost track of pointer targets
 //! - Non tracked function parameters cause incomplete taints that could miss possible dangerous inputs
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::{
     analysis::{
@@ -161,7 +161,7 @@ pub fn check_cwe(
         }
     }
 
-    let mut cwe_warnings = HashMap::new();
+    let mut cwe_warnings = BTreeMap::new();
     for cwe in cwe_receiver.try_iter() {
         match &cwe.addresses[..] {
             [taint_source_address, ..] => cwe_warnings.insert(taint_source_address.clone(), cwe),

--- a/src/cwe_checker_lib/src/checkers/cwe_782.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_782.rs
@@ -82,5 +82,6 @@ pub fn check_cwe(
             .iter()
             .for_each(|sub| warnings.append(&mut handle_sub(sub, symbol)));
     }
+    warnings.sort();
     (vec![], warnings)
 }


### PR DESCRIPTION
Each check now sorts its generated CWE warnings by the corresponding address. Fixes #220.