### PR TITLE
Publish Docker images on ghcr.io

### DIFF
--- a/.github/workflows/docker-publish-stable.yml
+++ b/.github/workflows/docker-publish-stable.yml
@@ -1,0 +1,31 @@
+name: Publish Docker images for release versions
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-publish-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get tag name
+        uses: olegtarasov/get-tag@v2.1
+        id: tagName
+
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to ghcr.io Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/fkie-cad/cwe_checker:${{ steps.tagName.outputs.tag }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,27 @@
+name: Publish Docker image based on master branch
+
+on:
+  push:
+    branches: ['master']
+
+jobs:
+  build-and-publish-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log in to ghcr.io Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/fkie-cad/cwe_checker:latest


### PR DESCRIPTION
Automatically build and publish Docker images on the ghcr.io container registry. Images are generated for pushes to the master branch (with tag 'latest') and for published releases (with tag the release tag). The Readme.md will be updated in a separate PR if this PR works as intended.