### PR TITLE
Add automatic pushes to Dockerhub to the CI

### DIFF
--- a/.github/workflows/docker-publish-stable.yml
+++ b/.github/workflows/docker-publish-stable.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Check functionality of the image
         run: docker run --rm cwe_checker:test /bin/echo | grep -q CWE676
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to ghcr.io Container registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -37,4 +44,8 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/fkie-cad/cwe_checker:${{ steps.tagName.outputs.tag }}
+          tags: |
+            fkiecad/cwe_checker:stable
+            fkiecad/cwe_checker:${{ steps.tagName.outputs.tag }}
+            ghcr.io/fkie-cad/cwe_checker:stable
+            ghcr.io/fkie-cad/cwe_checker:${{ steps.tagName.outputs.tag }}

--- a/.github/workflows/docker-publish-stable.yml
+++ b/.github/workflows/docker-publish-stable.yml
@@ -16,7 +16,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Log in to ghcr.io Container registry
+      - name: Build test docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          load: true
+          tags: cwe_checker:test
+
+      - name: Check functionality of the image
+        run: docker run --rm cwe_checker:test /bin/echo | grep -q CWE676
+
         uses: docker/login-action@v1
         with:
           registry: ghcr.io

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,13 @@ jobs:
       - name: Check functionality of the image
         run: docker run --rm cwe_checker:test /bin/echo | grep -q CWE676
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to ghcr.io Container registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
@@ -33,4 +40,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/fkie-cad/cwe_checker:latest
+          tags: |
+            fkiecad/cwe_checker:latest
+            ghcr.io/fkie-cad/cwe_checker:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Log in to ghcr.io Container registry
+      - name: Build test docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          load: true
+          tags: cwe_checker:test
+
+      - name: Check functionality of the image
+        run: docker run --rm cwe_checker:test /bin/echo | grep -q CWE676
+
         uses: docker/login-action@v1
         with:
           registry: ghcr.io


### PR DESCRIPTION
The Github action for automatically deploying Docker images is extended to also push the Docker images to Dockerhub.  This way we are no longer dependent on the automatic build feature of Dockerhub and can keep Dockerhub as the default container registry for cwe_checker Docker images.

Note that we keep ghcr.io as a secondary container registry so that we can quickly switch to it if Dockerhub deployments should break again in the future.