### PR TITLE
Correctly classify some buffer overflows as NULL dereferences

### DIFF
--- a/src/cwe_checker_lib/src/abstract_domain/data.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/data.rs
@@ -206,8 +206,8 @@ impl<T: RegisterDomain + Display> DataDomain<T> {
         }
         if self.contains_top_values {
             values.push(serde_json::Value::String(format!(
-                "Top:{}",
-                self.bytesize()
+                "Top:i{}",
+                self.bytesize().as_bit_length()
             )));
         }
         match values.len() {

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/mod.rs
@@ -516,6 +516,23 @@ impl<'a> Context<'a> {
         }
         ValueDomain::new_top(self.project.stack_pointer_register.size)
     }
+
+    /// Report a NULL dereference CWE at the address of the given TID.
+    fn report_null_deref(&self, tid: &Tid) {
+        let warning = CweWarning {
+            name: "CWE476".to_string(),
+            version: VERSION.to_string(),
+            addresses: vec![tid.address.clone()],
+            tids: vec![format!("{}", tid)],
+            symbols: Vec::new(),
+            other: Vec::new(),
+            description: format!(
+                "(NULL Pointer Dereference) Memory access at {} may result in a NULL dereference",
+                tid.address
+            ),
+        };
+        let _ = self.log_collector.send(LogThreadMsg::Cwe(warning));
+    }
 }
 
 #[cfg(test)]

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
@@ -15,6 +15,7 @@
 //! - [CWE-125](https://cwe.mitre.org/data/definitions/125.html) Buffer Overflow: Out-of-bounds Read
 //! - [CWE-415](https://cwe.mitre.org/data/definitions/415.html): Double Free
 //! - [CWE-416](https://cwe.mitre.org/data/definitions/416.html): Use After Free
+//! - [CWE-476](https://cwe.mitre.org/data/definitions/476.html): NULL Pointer Dereference
 //! - [CWE-787](https://cwe.mitre.org/data/definitions/787.html): Buffer Overflow: Out-of-bounds Write
 //!
 //! The analysis operates on a best-effort basis.

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
@@ -1085,3 +1085,35 @@ fn specialize_pointer_comparison() {
         .is_ok());
     assert_eq!(state.get_register(&register("RAX")), specialized_pointer);
 }
+
+#[test]
+fn test_check_def_for_null_dereferences() {
+    let mut state = State::new(&register("RSP"), Tid::new("func_tid"));
+    let var_rax = Variable::mock("RAX", 8);
+    let def = Def::load(
+        "load_def",
+        Variable::mock("RBX", 8),
+        Expression::Var(var_rax.clone()),
+    );
+    state.set_register(&var_rax, Bitvector::from_i64(0).into());
+    assert!(state.check_def_for_null_dereferences(&def).is_err());
+
+    state.set_register(&var_rax, Bitvector::from_i64(12345).into());
+    assert_eq!(
+        state.check_def_for_null_dereferences(&def).ok(),
+        Some(false)
+    );
+
+    state.set_register(&var_rax, IntervalDomain::mock(-2000, 5).into());
+    assert_eq!(state.check_def_for_null_dereferences(&def).ok(), Some(true));
+    assert_eq!(
+        state.get_register(&var_rax),
+        IntervalDomain::mock(-2000, -1024).into()
+    );
+
+    let mut address = state.get_register(&register("RSP"));
+    address.set_contains_top_flag();
+    address.set_absolute_value(Some(IntervalDomain::mock(0, 0xffff)));
+    state.set_register(&var_rax, address);
+    assert_eq!(state.check_def_for_null_dereferences(&def).ok(), Some(true));
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -184,7 +184,7 @@ mod tests {
         let num_cwes = String::from_utf8(output.stdout)
             .unwrap()
             .lines()
-            .filter(|line| line.starts_with("[CWE125]"))
+            .filter(|line| line.starts_with("[CWE476]"))
             .count();
         // We check the number of found CWEs only approximately
         // so that this check does not fail on minor result changes.


### PR DESCRIPTION
This PR adds a heuristic to detect cases where a buffer overflow CWE warning is in reality a potential NULL dereference. These cases are now correctly classified as NULL dereference CWE warnings.