### PR TITLE
add generic parameter objects for entry points

### DIFF
--- a/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
@@ -161,7 +161,16 @@ impl<'a> PointerInference<'a> {
             ));
         }
         for (sub_tid, start_node_index) in entry_sub_to_entry_node_map.into_iter() {
-            let mut fn_entry_state = State::new(&project.stack_pointer_register, sub_tid.clone());
+            let mut fn_entry_state = if let Some(cconv) = project.get_standard_calling_convention()
+            {
+                State::new_with_generic_parameter_objects(
+                    &project.stack_pointer_register,
+                    sub_tid.clone(),
+                    &cconv.integer_parameter_register,
+                )
+            } else {
+                State::new(&project.stack_pointer_register, sub_tid.clone())
+            };
             if project.cpu_architecture.contains("MIPS") {
                 let _ = fn_entry_state
                     .set_mips_link_register(&sub_tid, project.stack_pointer_register.size);
@@ -298,7 +307,16 @@ impl<'a> PointerInference<'a> {
                 [&self.computation.get_graph()[entry].get_block().tid]
                 .tid
                 .clone();
-            let mut fn_entry_state = State::new(&project.stack_pointer_register, sub_tid.clone());
+            let mut fn_entry_state = if let Some(cconv) = project.get_standard_calling_convention()
+            {
+                State::new_with_generic_parameter_objects(
+                    &project.stack_pointer_register,
+                    sub_tid.clone(),
+                    &cconv.integer_parameter_register,
+                )
+            } else {
+                State::new(&project.stack_pointer_register, sub_tid.clone())
+            };
             if project.cpu_architecture.contains("MIPS") {
                 let _ = fn_entry_state
                     .set_mips_link_register(&sub_tid, project.stack_pointer_register.size);

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/state/tests.rs
@@ -1117,3 +1117,16 @@ fn test_check_def_for_null_dereferences() {
     state.set_register(&var_rax, address);
     assert_eq!(state.check_def_for_null_dereferences(&def).ok(), Some(true));
 }
+
+#[test]
+fn test_new_with_generic_parameter_objects() {
+    let param_names = vec!["param1".to_string(), "param2".to_string()];
+    let state = State::new_with_generic_parameter_objects(
+        &register("RSP"),
+        Tid::new("func_tid"),
+        &param_names,
+    );
+    assert_eq!(state.memory.get_num_objects(), 3);
+    assert!(state.get_register_by_name("param1").is_some());
+    assert!(state.get_register_by_name("param2").is_some());
+}


### PR DESCRIPTION
Entry points are now generated with a list of generic parameter objects in the *Pointer Inference* analysis. In some cases this drastically increases the number of tracked memory operations, which at the moment outweighs the risk of introducing analysis errors through this change.