### PR TITLE
Suppress panic on invalid utf-8 in CWE78 check

### DIFF
--- a/src/cwe_checker_lib/src/checkers/cwe_78/state/mod.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78/state/mod.rs
@@ -227,7 +227,7 @@ impl State {
                     self.string_constants.insert(format_string.to_string());
                 }
                 // TODO: Change to log
-                Err(e) => panic!("{}", e),
+                Err(_e) => (),
             }
         }
     }


### PR DESCRIPTION
Fixes issue #236 by ignoring the corresponding error case. It isn't something that this check should handle by itself and a more sophisticated error handling seems not worthwhile at the moment, since the whole check may soon be replaced with the check in PR #235.