### PR TITLE
Add `podman` instructions to the tests building

### DIFF
--- a/test/artificial_samples/Readme.md
+++ b/test/artificial_samples/Readme.md
@@ -6,7 +6,7 @@ The provided dockerfile should be used for the build process.
 
 ## Prerequisites
 
-- Have Docker installed on your system
+- Have Docker or Podman installed on your system
 
 ## Build commands
 
@@ -15,4 +15,8 @@ Inside this directory run the following commands:
 docker build -t cross_compiling .
 docker run --rm -v $(pwd)/build:/home/cwe/artificial_samples/build cross_compiling sudo python3 -m SCons
 ```
-
+If instead of Docker you use Podman, it's necessary to add also the `--security-opt label=disable` for mounting the volume:
+```shell
+podman build -t cross_compiling .
+podman run --rm -v $(pwd)/build:/home/cwe/artificial_samples/build --security-opt label=disable cross_compiling sudo python3 -m SCons
+```


### PR DESCRIPTION
On RedHat distributions, like Fedora, CentOS, RHEL, etc [Podman](https://podman.io) becomes a popular root-less alternative to Docker. Thus, it's useful to add notes how to use it for building the tests.