### PR TITLE
Ensure correct handling of boolean negation

### DIFF
--- a/src/cwe_checker_lib/src/intermediate_representation/bitvector.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/bitvector.rs
@@ -84,6 +84,7 @@ impl BitvectorExtended for Bitvector {
                 if self.is_zero() {
                     Ok(Bitvector::from_u8(1))
                 } else {
+                    assert_eq!(self, &Bitvector::from_u8(1)); // Any other value would indicate a bug.
                     Ok(Bitvector::from_u8(0))
                 }
             }


### PR DESCRIPTION
Fixes #268.

If a boolean value is something else than 0 or 1 then the handling of boolean negation is possibly wrong. This is fixed by just asserting that the boolean value is 0 or 1. This way the cwe_checker crashes if this actually occurs somewhere and we are hopefully alerted of it so that we can fix the root cause of the bug. I tested it with several different binaries without any observed crashes. So I am confident that such bugs either do only occur very rarely or do not currently exist in the code base.