### PR TITLE
fix some (but not all) AVR8 issues

### DIFF
--- a/src/ghidra/p_code_extractor/internal/HelperFunctions.java
+++ b/src/ghidra/p_code_extractor/internal/HelperFunctions.java
@@ -94,13 +94,13 @@ public final class HelperFunctions {
 
 
     /**
-     * @param constant: Constant value
-     * @return: Constant value without prefix
+     * @param constant: Value which may have a prefix
+     * @return: Value without prefix
      * 
-     * Removes the consts prefix from the constant.
+     * Removes prefixes like "const:" and "mem:" from the constant.
      */
-    public static String removeConstantPrefix(String constant) {
-        return constant.replaceFirst("^(const:)", "");
+    public static String removePrefix(String constant) {
+        return constant.replaceFirst("^([a-zA-Z]*:)", "");
     }
 
 

--- a/src/ghidra/p_code_extractor/internal/ParseCspecContent.java
+++ b/src/ghidra/p_code_extractor/internal/ParseCspecContent.java
@@ -162,7 +162,7 @@ public class ParseCspecContent {
      */
     public static ResourceFile getLdefFile() {
         String processorDef = String.format("%s.ldefs", program.getLanguage().getLanguageDescription().getProcessor().toString());
-        if(processorDef.startsWith("MIPS")) {
+        if(processorDef.startsWith("MIPS") || processorDef.startsWith("AVR")) {
             processorDef = processorDef.toLowerCase();
         }
         if(processorDef.startsWith("PowerPC")) {

--- a/src/ghidra/p_code_extractor/internal/TermCreator.java
+++ b/src/ghidra/p_code_extractor/internal/TermCreator.java
@@ -31,7 +31,7 @@ public class TermCreator {
      */
     public static Term<Program> createProgramTerm() {
         Tid progTid = new Tid(String.format("prog_%s", HelperFunctions.ghidraProgram.getMinAddress().toString()), HelperFunctions.ghidraProgram.getMinAddress().toString());
-        String imageBase = HelperFunctions.ghidraProgram.getImageBase().toString();
+        String imageBase = HelperFunctions.removePrefix(HelperFunctions.ghidraProgram.getImageBase().toString());
         return new Term<Program>(progTid, new Program(new ArrayList<Term<Sub>>(), HelperFunctions.addEntryPoints(symTab), imageBase));
     }
 
@@ -195,10 +195,10 @@ public class TermCreator {
             var.setName(HelperFunctions.renameVirtualRegister(node.getAddress().toString()));
             var.setIsVirtual(true);
         } else if (node.isConstant()) {
-            var.setValue(HelperFunctions.removeConstantPrefix(node.getAddress().toString()));
+            var.setValue(HelperFunctions.removePrefix(node.getAddress().toString()));
             var.setIsVirtual(false);
         } else if (node.isAddress()) {
-            var.setAddress(node.getAddress().toString());
+            var.setAddress(HelperFunctions.removePrefix(node.getAddress().toString()));
             var.setIsVirtual(false);
         } else if (node.isFree()) {
             var.setAddress(HelperFunctions.removeStackPrefix(node.getAddress().toString()));


### PR DESCRIPTION
Fix some issues that lead to panics when trying to analyze binaries using the AVR8 instruction set architecture. However, some issues remain and thus it is still not possible to analyze AVR8-binaries (see issue #284 for details).