### PR TITLE
Fix intra-documentation links

### DIFF
--- a/.github/workflows/codestyle_checks.yml
+++ b/.github/workflows/codestyle_checks.yml
@@ -51,7 +51,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-          components: doc
+          components: rust-docs
       - uses: actions-rs/cargo@v1
         with:
           command: doc

--- a/.github/workflows/codestyle_checks.yml
+++ b/.github/workflows/codestyle_checks.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTDOCFLAGS: -Dwarnings
 
 jobs:
   fmt:
@@ -39,3 +40,19 @@ jobs:
         with:
           command: clippy
           args: -- -D clippy::all -D missing_docs
+
+  doc:
+    name: Rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: doc
+      - uses: actions-rs/cargo@v1
+        with:
+          command: doc
+          args: --no-deps --document-private-items

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ compile_test_files:
 codestyle-check:
 	cargo fmt -- --check
 	cargo clippy -- -D clippy::all -D missing_docs
+	RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps --document-private-items
 
 clean:
 	cargo clean

--- a/src/cwe_checker_lib/src/analysis/string_abstraction/context/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/string_abstraction/context/mod.rs
@@ -52,7 +52,7 @@ pub struct Context<'a, T: AbstractDomain + DomainInsertion + HasTop + Eq + From<
     /// The keys are of the form `(Def-TID, Current-Sub-TID)`
     /// to distinguish the nodes for blocks contained in more than one function.
     pub block_first_def_set: HashSet<(Tid, Tid)>,
-    /// A map to get the node index of the `BlkEnd` node containing a given [`Jmp`].
+    /// A map to get the node index of the `BlkEnd` node containing a given [`Jmp`](crate::intermediate_representation::Jmp).
     /// The keys are of the form `(Jmp-TID, Current-Sub-TID)`
     /// to distinguish the nodes for blocks contained in more than one function.
     pub jmp_to_blk_end_node_map: HashMap<(Tid, Tid), NodeIndex>,

--- a/src/cwe_checker_lib/src/intermediate_representation/blk.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/blk.rs
@@ -1,5 +1,4 @@
-use super::{Def, Jmp};
-use crate::prelude::*;
+use super::*;
 use crate::utils::log::LogMessage;
 use std::collections::HashSet;
 
@@ -34,7 +33,7 @@ pub struct Blk {
     /// this field contains possible jump target addresses for the jump.
     ///
     /// Note that possible targets of indirect calls are *not* contained,
-    /// since the [`Project::make_block_to_sub_mapping_unique`] normalization pass assumes
+    /// since the [`Project` normalization passes](Project::normalize) assume
     /// that only intraprocedural jump targets are contained in this field.
     pub indirect_jmp_targets: Vec<Tid>,
 }
@@ -75,9 +74,9 @@ impl Term<Blk> {
     /// Note that substitution is only possible
     /// if the input variables of the input expression itself did not change since the definition of said variable.
     ///
-    /// The expression propagation allows the [`Project::substitute_trivial_expressions`] normalization pass
+    /// The expression propagation allows the corresponding [`Project` normalization pass](Project::normalize)
     /// to further simplify the generated expressions
-    /// and allows more dead stores to be removed during [dead variable elimination](`crate::analysis::dead_variable_elimination`).
+    /// and allows more dead stores to be removed during [dead variable elimination](crate::analysis::dead_variable_elimination).
     pub fn propagate_input_expressions(&mut self) {
         let mut insertable_expressions = Vec::new();
         for def in self.term.defs.iter_mut() {
@@ -143,7 +142,7 @@ impl Term<Blk> {
     /// Merge subsequent assignments to the same variable to a single assignment to that variable.
     ///
     /// The value expressions of merged assignments can often be simplified later on
-    /// in the [`Project::substitute_trivial_expressions`] normalization pass.
+    /// in the corresponding [`Project` normalization pass](Project::normalize).
     pub fn merge_def_assignments_to_same_var(&mut self) {
         let mut new_defs = Vec::new();
         let mut last_def_opt = None;

--- a/src/cwe_checker_lib/src/intermediate_representation/project/block_duplication_normalization.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/project/block_duplication_normalization.rs
@@ -65,7 +65,7 @@ impl Project {
     }
 
     /// Generate a map from all `Sub` TIDs to the set TIDs of all contained blocks in the `Sub`.
-    /// Used for the [`Project::make_block_to_sub_mapping_unique`] normalization pass,
+    /// Used for the [`make_block_to_sub_mapping_unique`] normalization pass,
     /// as this function assumes that there may exist blocks contained in more than one `Sub`.
     fn generate_sub_tid_to_contained_block_tids_map(
         &self,
@@ -110,7 +110,7 @@ impl Project {
     /// The TIDs of jump and return targets are not adjusted in this function.
     /// The returned map maps the TID of a `Sub` to the newly created blocks for that `Sub`.
     ///
-    /// This function is part of the [`Project::make_block_to_sub_mapping_unique`] normalization pass
+    /// This function is part of the [`make_block_to_sub_mapping_unique`] normalization pass
     /// and should not be used for other purposes.
     fn duplicate_blocks_contained_in_several_subs(
         &self,
@@ -141,7 +141,7 @@ impl Project {
     /// if the target block was duplicated by the [`Project::duplicate_blocks_contained_in_several_subs`] function,
     /// so that the jumps target the correct blocks again.
     ///
-    /// This function is part of the [`Project::make_block_to_sub_mapping_unique`] normalization pass
+    /// This function is part of the [`make_block_to_sub_mapping_unique`] normalization pass
     /// and should not be used for other purposes.
     fn append_jump_targets_with_sub_suffix_when_target_block_was_duplicated(
         &mut self,


### PR DESCRIPTION
Fixes some broken intra-documentation links. Also adds a documentation build pass to the CI, so that it now automatically fails if broken documentation links (or other documentation warnings) are detected.