### PR TITLE
fix crash on division of bitvectors longer than 8 bytes

### DIFF
--- a/src/cwe_checker_lib/src/intermediate_representation/bitvector.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/bitvector.rs
@@ -173,8 +173,22 @@ impl BitvectorExtended for Bitvector {
                     Ok(self.clone().into_checked_sdiv(rhs)?)
                 }
             }
-            IntRem => Ok(self.clone().into_checked_urem(rhs)?),
-            IntSRem => Ok(self.clone().into_checked_srem(rhs)?),
+            IntRem => {
+                // FIXME: Division for bitvectors larger than 8 bytes is not yet implemented in the `apint` crate (version 0.2).
+                if self.width().to_usize() > 64 {
+                    Err(anyhow!("Multiplication and division of integers larger than 8 bytes not yet implemented."))
+                } else {
+                    Ok(self.clone().into_checked_urem(rhs)?)
+                }
+            }
+            IntSRem => {
+                // FIXME: Division for bitvectors larger than 8 bytes is not yet implemented in the `apint` crate (version 0.2).
+                if self.width().to_usize() > 64 {
+                    Err(anyhow!("Multiplication and division of integers larger than 8 bytes not yet implemented."))
+                } else {
+                    Ok(self.clone().into_checked_srem(rhs)?)
+                }
+            }
             IntLeft => {
                 let shift_amount = rhs.try_to_u64().unwrap() as usize;
                 if shift_amount < self.width().to_usize() {


### PR DESCRIPTION
The `apint` crate that we use to represent bitvectors does not yet support division of bitvectors of length longer than 8 bytes. We catch these cases and just do not execute such operations (and instead approximate them with an unknown result in the corresponding abstract domain). But we forgot to also catch the "compute remainder" versions of bitvector division, which lead to crashes when they occured. This PR fixes that.

Fixes issue #307.