### PR TITLE
Prevent false double free warnings for parameter objects

### DIFF
--- a/src/cwe_checker_lib/src/analysis/pointer_inference/object/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/object/mod.rs
@@ -153,13 +153,8 @@ impl AbstractObject {
     }
 
     /// Mark the memory object as freed.
-    /// Returns an error if a possible double free is detected
-    /// or the memory object may not be a heap object.
+    /// Returns an error if a possible double free is detected.
     pub fn mark_as_freed(&mut self) -> Result<(), Error> {
-        if self.inner.type_ != Some(ObjectType::Heap) {
-            self.set_state(ObjectState::Flagged);
-            return Err(anyhow!("Free operation on possibly non-heap memory object"));
-        }
         let inner = Arc::make_mut(&mut self.inner);
         match (inner.is_unique, inner.state) {
             (true, ObjectState::Alive) | (true, ObjectState::Flagged) => {
@@ -182,13 +177,8 @@ impl AbstractObject {
     }
 
     /// Mark the memory object as possibly (but not definitely) freed.
-    /// Returns an error if the object was definitely freed before
-    /// or if the object may not be a heap object.
+    /// Returns an error if the object was definitely freed before.
     pub fn mark_as_maybe_freed(&mut self) -> Result<(), Error> {
-        if self.inner.type_ != Some(ObjectType::Heap) {
-            self.set_state(ObjectState::Flagged);
-            return Err(anyhow!("Free operation on possibly non-heap memory object"));
-        }
         let inner = Arc::make_mut(&mut self.inner);
         match inner.state {
             ObjectState::Dangling => {


### PR DESCRIPTION
The recent overhaul of the pointer inference analysis lead to many instances of false double free CWE warnings, caused by calling `free` on parameter objects, being generated. This PR fixes this bug. Please note that we are still working on complete overhauls of the buffer overflow and use-after-free checks to properly adapt them to the new pointer inference analysis. This PR is not that but just a small bugfix for a rather common false positive CWE warning.