### PR TITLE
activate more x86 acceptance tests

### DIFF
--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -244,8 +244,6 @@ mod tests {
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
 
-        mark_skipped(&mut tests, "x86", "gcc"); // Loss of stack register value since we do not track pointer alignment yet.
-
         mark_compiler_skipped(&mut tests, "mingw32-gcc"); // TODO: Check reason for failure!
 
         for test_case in tests {
@@ -271,7 +269,7 @@ mod tests {
 
         mark_skipped(&mut tests, "ppc", "gcc"); // Needs tracking of linear dependencies between register values.
 
-        mark_skipped(&mut tests, "x86", "gcc"); // Loss of stack register value since we do not track pointer alignment yet.
+        mark_skipped(&mut tests, "x86", "gcc"); // Unrelated third CWE hit in `__libc_csu_init`
         mark_skipped(&mut tests, "x86", "clang"); // Unrelated third CWE hit in `__libc_csu_init`
 
         mark_compiler_skipped(&mut tests, "mingw32-gcc"); // TODO: Check reason for failure!
@@ -428,11 +426,6 @@ mod tests {
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
 
-        // The analysis loses track of the stack pointer offset in the main() function
-        // because of a "INT_AND ESP 0xfffffff0" instruction.
-        // We would need knowledge about alignment guarantees for the stack pointer at the start of main() to fix this.
-        mark_skipped(&mut tests, "x86", "gcc");
-
         mark_skipped(&mut tests, "x86", "mingw32-gcc"); // TODO: Check reason for failure! Probably same as above?
 
         for test_case in tests {
@@ -455,11 +448,6 @@ mod tests {
 
         mark_architecture_skipped(&mut tests, "ppc64"); // Ghidra generates mangled function names here for some reason.
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
-
-        // The analysis loses track of the stack pointer offset in the main() function
-        // because of a "INT_AND ESP 0xfffffff0" instruction.
-        // We would need knowledge about alignment guarantees for the stack pointer at the start of main() to fix this.
-        mark_skipped(&mut tests, "x86", "gcc");
 
         mark_skipped(&mut tests, "x86", "mingw32-gcc"); // TODO: Check reason for failure! Probably same as above?
 
@@ -638,8 +626,6 @@ mod tests {
         mark_architecture_skipped(&mut tests, "ppc64le"); // Ghidra generates mangled function names here for some reason.
 
         mark_skipped(&mut tests, "ppc", "gcc"); // Needs tracking of linear dependencies between register values.
-
-        mark_skipped(&mut tests, "x86", "gcc"); // Loss of stack register value since we do not track pointer alignment yet.
 
         mark_compiler_skipped(&mut tests, "mingw32-gcc"); // TODO: Check reason for failure!
 


### PR DESCRIPTION
We can now activate some acceptance tests for x86-gcc that were failing prior to PR #317.