### PR TITLE
Update docker action

### DIFF
--- a/.github/workflows/docker-publish-stable.yml
+++ b/.github/workflows/docker-publish-stable.yml
@@ -51,7 +51,7 @@ jobs:
           context: .
           platforms: |
             linux/amd64
-            linux/arm64
+            # linux/arm64  # temporarily disabled due to memory exhaustion problems in the CI
           push: true
           tags: |
             fkiecad/cwe_checker:stable

--- a/.github/workflows/docker-publish-stable.yml
+++ b/.github/workflows/docker-publish-stable.yml
@@ -45,13 +45,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The linux/arm64 platform target has been temporarily disabled due to memory exhaustion problems in the CI
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
           platforms: |
             linux/amd64
-            # linux/arm64  # temporarily disabled due to memory exhaustion problems in the CI
           push: true
           tags: |
             fkiecad/cwe_checker:stable

--- a/.github/workflows/docker-publish-stable.yml
+++ b/.github/workflows/docker-publish-stable.yml
@@ -17,13 +17,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build test docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           load: true
@@ -33,20 +33,20 @@ jobs:
         run: docker run --rm cwe_checker:test /bin/echo | grep -q CWE676
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ghcr.io Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -47,7 +47,7 @@ jobs:
           context: .
           platforms: |
             linux/amd64
-            linux/arm64
+            # linux/arm64  # temporarily disabled due to memory exhaustion problems in the CI
           push: true
           tags: |
             fkiecad/cwe_checker:latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker image based on master branch
 
 on:
   push:
-    branches: ['master', 'update_docker_action']
+    branches: ['master']
 
 jobs:
   build-and-publish-image:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,7 +2,7 @@ name: Publish Docker image based on master branch
 
 on:
   push:
-    branches: ['master']
+    branches: ['master', 'update_docker_action']
 
 jobs:
   build-and-publish-image:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,13 +13,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Build test docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           load: true
@@ -29,20 +29,20 @@ jobs:
         run: docker run --rm cwe_checker:test /bin/echo | grep -q CWE676
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to ghcr.io Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,13 +41,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The linux/arm64 platform target has been temporarily disabled due to memory exhaustion problems in the CI
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
           platforms: |
             linux/amd64
-            # linux/arm64  # temporarily disabled due to memory exhaustion problems in the CI
           push: true
           tags: |
             fkiecad/cwe_checker:latest


### PR DESCRIPTION
Update the CI actions to use the newest versions of the corresponding Github Actions when building and publishing the Docker containers. Also disable the cross compilation Docker build for the ARM64 target. Apparently this leads to memory exhaustion problems in the CI, which in turn lead to the corresponding action getting killed before completion. We either have to wait until this gets fixed upstream by the Docker cross compilation build environment or we have to find a way to build the ARM versions of the Docker containers that does not rely on emulation.