### PR TITLE
Bugfix: prevent creation of duplicated block term

### DIFF
--- a/src/ghidra/p_code_extractor/internal/JumpProcessing.java
+++ b/src/ghidra/p_code_extractor/internal/JumpProcessing.java
@@ -211,7 +211,10 @@ public final class JumpProcessing {
     public static void addMissingJumpAfterInstructionSplit(Term<Blk> lastBlock) {
         lastBlock.getTerm().addMultipleDefs(PcodeBlockData.temporaryDefStorage);
         addBranchToCurrentBlock(lastBlock.getTerm(), PcodeBlockData.instruction.getAddress().toString(), PcodeBlockData.instruction.getFallThrough().toString());
-        PcodeBlockData.blocks.add(TermCreator.createBlkTerm(PcodeBlockData.instruction.getFallThrough().toString(), null));
+        // If and only if the jump target is still part of the same Ghidra block, we need to start a new block term for it.
+        if (PcodeBlockData.instructionIndex != PcodeBlockData.numberOfInstructionsInBlock - 1) {
+            PcodeBlockData.blocks.add(TermCreator.createBlkTerm(PcodeBlockData.instruction.getFallThrough().toString(), null));
+        } 
         PcodeBlockData.temporaryDefStorage.clear();
     }
 


### PR DESCRIPTION
Fix a bug that caused duplicated block terms to be created in the rare case that the target of an intra-instruction conditional jump to the fallthrough instruction was already the start of a regular block term. These duplicated blocks were empty and caused errors in the control flow graph.