### PR TITLE
add global memory tracking to FunctionSignature analysis

### DIFF
--- a/src/cwe_checker_lib/src/abstract_domain/identifier.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/identifier.rs
@@ -86,6 +86,18 @@ impl AbstractIdentifier {
         AbstractIdentifier::new(time.clone(), location)
     }
 
+    /// Create an abstract identifier from an address into global memory.
+    pub fn from_global_address(
+        time: &Tid,
+        address: &Bitvector,
+        size: ByteSize,
+    ) -> AbstractIdentifier {
+        AbstractIdentifier::new(
+            time.clone(),
+            AbstractLocation::from_global_address(address, size),
+        )
+    }
+
     /// Create a new abstract identifier
     /// by pushing the given path hint to the array of path hints of `self`.
     /// Returns an error if the path hint is already contained in the path hints of `self`.
@@ -106,11 +118,13 @@ impl AbstractIdentifier {
     }
 
     /// Get the register associated to the abstract location.
-    /// Panics if the abstract location is a memory location and not a register.
+    /// Panics if the abstract location is not a register but a memory location.
     pub fn unwrap_register(&self) -> &Variable {
         match &self.location {
             AbstractLocation::Register(var) => var,
-            AbstractLocation::Pointer(_, _) => panic!("Abstract location is not a register."),
+            AbstractLocation::GlobalValue { .. }
+            | AbstractLocation::GlobalPointer(_, _)
+            | AbstractLocation::Pointer(_, _) => panic!("Abstract location is not a register."),
         }
     }
 
@@ -153,18 +167,29 @@ impl std::fmt::Display for AbstractIdentifier {
 pub enum AbstractLocation {
     /// The location is given by a register.
     Register(Variable),
+    /// The location is given by a constant address in global memory.
+    GlobalValue { address: u64, size: ByteSize },
     /// The location is in memory.
     /// One needs to follow the pointer in the given register
     /// and then follow the abstract memory location inside the pointed to memory object
     /// to find the actual memory location.
     Pointer(Variable, AbstractMemoryLocation),
+    /// The location is in memory.
+    /// One needs to follow the pointer located at the given global address
+    /// and then follow the abstract memory location inside the pointed to memory object
+    /// to find the actual memory location.
+    GlobalPointer(u64, AbstractMemoryLocation),
 }
 
 impl std::fmt::Display for AbstractLocation {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Register(var) => write!(formatter, "{}", var.name),
+            Self::GlobalValue { address, size: _ } => write!(formatter, "0x{:x}", address),
             Self::Pointer(var, location) => write!(formatter, "{}->{}", var.name, location),
+            Self::GlobalPointer(address, location) => {
+                write!(formatter, "0x{:x}->{}", address, location)
+            }
         }
     }
 }
@@ -193,11 +218,22 @@ impl AbstractLocation {
         AbstractLocation::Pointer(stack_register.clone(), stack_pos)
     }
 
+    /// Create an abstract location pointing to a value in global memory.
+    pub fn from_global_address(address: &Bitvector, size: ByteSize) -> AbstractLocation {
+        let address = address
+            .try_to_u64()
+            .expect("Global address larger than 64 bits encountered.");
+        AbstractLocation::GlobalValue { address, size }
+    }
+
     /// Get the bytesize of the value represented by the abstract location.
     pub fn bytesize(&self) -> ByteSize {
         match self {
             Self::Register(var) => var.size,
-            Self::Pointer(_pointer_var, mem_location) => mem_location.bytesize(),
+            Self::GlobalValue { size, .. } => *size,
+            Self::Pointer(_, mem_location) | Self::GlobalPointer(_, mem_location) => {
+                mem_location.bytesize()
+            }
         }
     }
 }

--- a/src/cwe_checker_lib/src/abstract_domain/identifier.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/identifier.rs
@@ -163,7 +163,12 @@ pub enum AbstractLocation {
     /// The value itself is a constant address to global memory.
     /// Note that the `size` is the size of the pointer and not the size
     /// of the value residing at the specific address in global memory.
-    GlobalAddress { address: u64, size: ByteSize },
+    GlobalAddress {
+        /// The address in global memory.
+        address: u64,
+        /// The byte size of the address (not the pointed-to value!).
+        size: ByteSize,
+    },
     /// The location is in memory.
     /// One needs to follow the pointer in the given register
     /// and then follow the abstract memory location inside the pointed to memory object

--- a/src/cwe_checker_lib/src/abstract_domain/identifier.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/identifier.rs
@@ -87,15 +87,8 @@ impl AbstractIdentifier {
     }
 
     /// Create an abstract identifier from an address into global memory.
-    pub fn from_global_address(
-        time: &Tid,
-        address: &Bitvector,
-        size: ByteSize,
-    ) -> AbstractIdentifier {
-        AbstractIdentifier::new(
-            time.clone(),
-            AbstractLocation::from_global_address(address, size),
-        )
+    pub fn from_global_address(time: &Tid, address: &Bitvector) -> AbstractIdentifier {
+        AbstractIdentifier::new(time.clone(), AbstractLocation::from_global_address(address))
     }
 
     /// Create a new abstract identifier
@@ -122,7 +115,7 @@ impl AbstractIdentifier {
     pub fn unwrap_register(&self) -> &Variable {
         match &self.location {
             AbstractLocation::Register(var) => var,
-            AbstractLocation::GlobalValue { .. }
+            AbstractLocation::GlobalAddress { .. }
             | AbstractLocation::GlobalPointer(_, _)
             | AbstractLocation::Pointer(_, _) => panic!("Abstract location is not a register."),
         }
@@ -167,8 +160,10 @@ impl std::fmt::Display for AbstractIdentifier {
 pub enum AbstractLocation {
     /// The location is given by a register.
     Register(Variable),
-    /// The location is given by a constant address in global memory.
-    GlobalValue { address: u64, size: ByteSize },
+    /// The value itself is a constant address to global memory.
+    /// Note that the `size` is the size of the pointer and not the size
+    /// of the value residing at the specific address in global memory.
+    GlobalAddress { address: u64, size: ByteSize },
     /// The location is in memory.
     /// One needs to follow the pointer in the given register
     /// and then follow the abstract memory location inside the pointed to memory object
@@ -185,7 +180,7 @@ impl std::fmt::Display for AbstractLocation {
     fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Register(var) => write!(formatter, "{}", var.name),
-            Self::GlobalValue { address, size: _ } => write!(formatter, "0x{:x}", address),
+            Self::GlobalAddress { address, size: _ } => write!(formatter, "0x{:x}", address),
             Self::Pointer(var, location) => write!(formatter, "{}->{}", var.name, location),
             Self::GlobalPointer(address, location) => {
                 write!(formatter, "0x{:x}->{}", address, location)
@@ -218,19 +213,20 @@ impl AbstractLocation {
         AbstractLocation::Pointer(stack_register.clone(), stack_pos)
     }
 
-    /// Create an abstract location pointing to a value in global memory.
-    pub fn from_global_address(address: &Bitvector, size: ByteSize) -> AbstractLocation {
+    /// Create an abstract location representing an address pointing to global memory.
+    pub fn from_global_address(address: &Bitvector) -> AbstractLocation {
+        let size = address.bytesize();
         let address = address
             .try_to_u64()
             .expect("Global address larger than 64 bits encountered.");
-        AbstractLocation::GlobalValue { address, size }
+        AbstractLocation::GlobalAddress { address, size }
     }
 
     /// Get the bytesize of the value represented by the abstract location.
     pub fn bytesize(&self) -> ByteSize {
         match self {
             Self::Register(var) => var.size,
-            Self::GlobalValue { size, .. } => *size,
+            Self::GlobalAddress { size, .. } => *size,
             Self::Pointer(_, mem_location) | Self::GlobalPointer(_, mem_location) => {
                 mem_location.bytesize()
             }

--- a/src/cwe_checker_lib/src/analysis/callgraph.rs
+++ b/src/cwe_checker_lib/src/analysis/callgraph.rs
@@ -1,0 +1,75 @@
+//! Generate call graphs out of a program term.
+
+use std::collections::HashMap;
+
+use crate::intermediate_representation::*;
+use petgraph::graph::DiGraph;
+
+/// The graph type of a call graph
+pub type CallGraph<'a> = DiGraph<Tid, &'a Term<Jmp>>;
+
+/// Generate a call graph for the given program.
+///
+/// The nodes of the returned graph correspond to the TIDs of functions in the program.
+/// Edges are jump terms of call operations.
+///
+/// Note that calls to external symbols are not represented in the graph,
+/// i.e. there are neither nodes nor edges representing (calls to) external symbols in the graph.
+/// Also, there are currently no edges for indirect calls,
+/// because a corresponding analysis for resolving indirect calls is not implemented yet.
+pub fn get_program_callgraph(program: &Term<Program>) -> CallGraph {
+    let mut callgraph = CallGraph::new();
+    let mut tid_to_node_index_map = HashMap::new();
+    for sub_tid in program.term.subs.keys() {
+        let node_index = callgraph.add_node(sub_tid.clone());
+        tid_to_node_index_map.insert(sub_tid.clone(), node_index);
+    }
+    for sub in program.term.subs.values() {
+        let source_index = tid_to_node_index_map.get(&sub.tid).unwrap();
+        for block in &sub.term.blocks {
+            for jump in &block.term.jmps {
+                if let Jmp::Call { target, .. } = &jump.term {
+                    if let Some(target_index) = tid_to_node_index_map.get(target) {
+                        callgraph.add_edge(*source_index, *target_index, jump);
+                    }
+                }
+            }
+        }
+    }
+
+    callgraph
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_program_callgraph() {
+        // Create a program with 2 functions and one call between them
+        let mut project = Project::mock_x64();
+        let mut caller = Sub::mock("caller");
+        let callee = Sub::mock("callee");
+        let call = Jmp::Call {
+            target: Tid::new("callee"),
+            return_: None,
+        };
+        let mut call_block = Blk::mock();
+        call_block.term.jmps.push(Term {
+            tid: Tid::new("call"),
+            term: call,
+        });
+        caller.term.blocks.push(call_block);
+        project.program.term.subs.insert(Tid::new("caller"), caller);
+        project.program.term.subs.insert(Tid::new("callee"), callee);
+        // Test correctness of the call graph
+        let callgraph = get_program_callgraph(&project.program);
+        assert_eq!(callgraph.node_indices().len(), 2);
+        assert_eq!(callgraph.edge_indices().len(), 1);
+        let (start, end) = callgraph
+            .edge_endpoints(callgraph.edge_indices().next().unwrap())
+            .unwrap();
+        assert_eq!(callgraph[start], Tid::new("caller"));
+        assert_eq!(callgraph[end], Tid::new("callee"));
+    }
+}

--- a/src/cwe_checker_lib/src/analysis/function_signature/global_var_propagation.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/global_var_propagation.rs
@@ -1,0 +1,298 @@
+//! This module implements propagation of global variables via two fixpoint algorithms on the call graph.
+//! For more details see [`propagate_globals`].
+
+use super::AccessPattern;
+use super::FunctionSignature;
+use crate::abstract_domain::AbstractDomain;
+use crate::abstract_domain::DomainMap;
+use crate::abstract_domain::UnionMergeStrategy;
+use crate::analysis::callgraph::get_program_callgraph;
+use crate::analysis::callgraph::CallGraph;
+use crate::analysis::fixpoint::{Computation, Context};
+use crate::intermediate_representation::*;
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+
+/// The context object for propagating known global variables top-down in the call graph.
+struct KnownGlobalsContext<'a> {
+    /// The call graph of the program.
+    graph: &'a CallGraph<'a>,
+}
+
+impl<'a> KnownGlobalsContext<'a> {
+    /// Create a new context object.
+    fn new(graph: &'a CallGraph<'a>) -> Self {
+        KnownGlobalsContext { graph }
+    }
+}
+
+impl<'a> Context for KnownGlobalsContext<'a> {
+    type EdgeLabel = &'a Term<Jmp>;
+    type NodeLabel = Tid;
+    /// The values at nodes are the sets of known addresses of global variables for that function.
+    type NodeValue = HashSet<u64>;
+
+    /// Get the call graph corresponding to the context object.
+    fn get_graph(&self) -> &CallGraph<'a> {
+        self.graph
+    }
+
+    /// The merge function returns the union of the two input sets of global addresses.
+    fn merge(&self, set1: &HashSet<u64>, set2: &HashSet<u64>) -> HashSet<u64> {
+        let mut result = set1.clone();
+        for address in set2 {
+            result.insert(*address);
+        }
+        result
+    }
+
+    /// We always propagate all known addresses of global variables along the edges of the call graph.
+    fn update_edge(
+        &self,
+        globals: &HashSet<u64>,
+        _edge: petgraph::stable_graph::EdgeIndex,
+    ) -> Option<HashSet<u64>> {
+        Some(globals.clone())
+    }
+}
+
+/// For each function in the call graph,
+/// compute the set of global addresses that are known to the function itself
+/// or at least one function that calls this function (either directly or indirectly).
+///
+/// This is computed via a fixpoint algorithm on the call graph of the program,
+/// where known addresses of global variables are propagated top-down along the edges of the call graph.
+fn propagate_known_globals_top_down(
+    project: &Project,
+    fn_sigs: &BTreeMap<Tid, FunctionSignature>,
+) -> BTreeMap<Tid, HashSet<u64>> {
+    let graph = get_program_callgraph(&project.program);
+    let context = KnownGlobalsContext::new(&graph);
+    let mut computation = Computation::new(context, None);
+
+    // Set the start values of all nodes
+    for node in graph.node_indices() {
+        let fn_tid = &graph[node];
+        let fn_sig = &fn_sigs[fn_tid];
+        let globals = fn_sig.global_parameters.keys().cloned().collect();
+        computation.set_node_value(node, globals);
+    }
+    // Propagate top-down in the call graph
+    computation.compute_with_max_steps(100);
+    // Generate results map
+    let mut results = BTreeMap::new();
+    for node in graph.node_indices() {
+        let fn_tid = &graph[node];
+        let propagated_globals = computation.get_node_value(node).unwrap();
+        results.insert(fn_tid.clone(), propagated_globals.clone());
+    }
+
+    results
+}
+
+/// The context object for propagating the access patterns of global variables in the call graph.
+struct GlobalsPropagationContext<'a> {
+    /// The reversed (!) call graph of the program.
+    graph: &'a CallGraph<'a>,
+    /// A map from TIDs of functions to the set of known addresses of global variables for that function.
+    known_globals: &'a BTreeMap<Tid, HashSet<u64>>,
+}
+
+impl<'a> GlobalsPropagationContext<'a> {
+    /// Create a new [`GlobalsPropagationContext`] object.
+    fn new(graph: &'a CallGraph<'a>, known_globals: &'a BTreeMap<Tid, HashSet<u64>>) -> Self {
+        GlobalsPropagationContext {
+            graph,
+            known_globals,
+        }
+    }
+}
+
+impl<'a> Context for GlobalsPropagationContext<'a> {
+    type EdgeLabel = &'a Term<Jmp>;
+    type NodeLabel = Tid;
+    /// The node values for the fixpoint comutation
+    /// are maps from addresses of global variables known to the function represented by the node
+    /// to the corresponding access pattern of the global variable.
+    type NodeValue = DomainMap<u64, AccessPattern, UnionMergeStrategy>;
+
+    /// Get the (reversed!) call graph corresponding to the program
+    fn get_graph(&self) -> &CallGraph<'a> {
+        self.graph
+    }
+
+    /// Merge two maps of known globals by merging the corresponding access patterns.
+    fn merge(&self, globals1: &Self::NodeValue, globals2: &Self::NodeValue) -> Self::NodeValue {
+        globals1.merge(globals2)
+    }
+
+    /// Propagate the access patterns of global variables along the edges of the reversed call graph.
+    ///
+    /// Access patterns are propagated from callees to callers,
+    /// but only for those global variables, that are also known to the caller.
+    fn update_edge(
+        &self,
+        callee_globals: &Self::NodeValue,
+        edge: petgraph::stable_graph::EdgeIndex,
+    ) -> Option<Self::NodeValue> {
+        let (_, target_node) = self.graph.edge_endpoints(edge).unwrap();
+        let target_tid = &self.graph[target_node];
+        let caller_known_globals = &self.known_globals[target_tid];
+
+        let caller_globals: Self::NodeValue = callee_globals
+            .iter()
+            .filter_map(|(address, access_pattern)| {
+                if caller_known_globals.contains(address) && access_pattern.is_accessed() {
+                    Some((*address, *access_pattern))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        Some(caller_globals)
+    }
+}
+
+/// Propagate the access patterns of global variables bottom-up in the call graph.
+///
+/// Only those global variables (and their access patterns) are propagated,
+/// that are known to the caller anyway (i.e. some function upwards in the call graph accesses the global variable).
+fn propagate_globals_bottom_up(
+    project: &Project,
+    known_globals: &BTreeMap<Tid, HashSet<u64>>,
+    fn_sigs: &mut BTreeMap<Tid, FunctionSignature>,
+) {
+    // To propagate bottom-up, we have to reverse the edges in the callgraph
+    let mut graph = get_program_callgraph(&project.program);
+    graph.reverse();
+
+    let context = GlobalsPropagationContext::new(&graph, known_globals);
+    let mut computation = Computation::new(context, None);
+    // Set start values for all nodes
+    for node in graph.node_indices() {
+        let fn_tid = &graph[node];
+        let fn_sig = &fn_sigs[fn_tid];
+        let globals = fn_sig
+            .global_parameters
+            .iter()
+            .filter_map(|(address, access_pattern)| {
+                if access_pattern.is_accessed() {
+                    Some((*address, *access_pattern))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        computation.set_node_value(node, globals);
+    }
+    // Compute the fixpoint
+    computation.compute_with_max_steps(100);
+    if !computation.has_stabilized() {
+        panic!("Global parameter propagation algorithm did not stabilize.")
+    }
+    // Add the propagated globals to the function signatures
+    for node in graph.node_indices() {
+        let fn_tid = &graph[node];
+        let propagated_globals = computation.get_node_value(node).unwrap();
+        let fn_globals = &mut fn_sigs.get_mut(fn_tid).unwrap().global_parameters;
+        for (address, propagated_access_pattern) in propagated_globals.iter() {
+            fn_globals
+                .entry(*address)
+                .and_modify(|access_pattern| {
+                    *access_pattern = access_pattern.merge(propagated_access_pattern);
+                })
+                .or_insert(*propagated_access_pattern);
+        }
+    }
+}
+
+/// Propagate the access patterns of global variables along the edges of the call graph of the given project.
+///
+/// The propagation works as follows:
+/// Global variables and their access patterns are only propagated from callees to callers
+/// and only if some function upwards in the call-stack also accesses the corresponding variable.
+/// As usual, access patterns are merged if the caller also may access a global variable.
+///
+/// This propagation scheme is optimized for usage with other bottom-up analyses:
+/// - If some callee of a function accesses the same global variable as the function itself,
+///   then we need to propagate the corresponding access pattern to the function.
+///   This ensures that the function knows which callees may modify the value of the global variable.
+/// - If two callees of a function access a global variable,
+///   then there is no information flow on the value of the global variable between the callees in a proper bottom-up analysis.
+///   But if the function itself (or any of its callers) do not access the global variable,
+///   then there is no benefit in tracking its value for the function itself.
+///   Thus, the global variable should not be propagated to the function in such a case.
+pub fn propagate_globals(project: &Project, fn_sigs: &mut BTreeMap<Tid, FunctionSignature>) {
+    let known_globals = propagate_known_globals_top_down(project, fn_sigs);
+    propagate_globals_bottom_up(project, &known_globals, fn_sigs);
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn test_globals_propagation() {
+        let mut project = Project::mock_arm32();
+        // Add 3 functions, so that the call graph will look like this:
+        // main -> callee1 -> callee2
+        let mut func = Sub::mock("main");
+        let mut call_blk = Blk::mock_with_tid("main_blk");
+        let call = Jmp::mock_call("callee1", None);
+        call_blk.term.jmps.push(call);
+        func.term.blocks.push(call_blk);
+        project.program.term.subs.insert(Tid::new("main"), func);
+
+        let mut func = Sub::mock("callee1");
+        let mut call_blk = Blk::mock_with_tid("callee1_blk");
+        let call = Jmp::mock_call("callee2", None);
+        call_blk.term.jmps.push(call);
+        func.term.blocks.push(call_blk);
+        project.program.term.subs.insert(Tid::new("callee1"), func);
+
+        let func = Sub::mock("callee2");
+        project.program.term.subs.insert(Tid::new("callee2"), func);
+
+        // Add one global var that is known to main and callee2
+        // and another that is only known to callee1
+        let mut sig_main = FunctionSignature::new();
+        sig_main
+            .global_parameters
+            .insert(1000, AccessPattern::new().with_read_flag());
+        let mut sig_callee1 = FunctionSignature::new();
+        sig_callee1
+            .global_parameters
+            .insert(2000, AccessPattern::new().with_dereference_flag());
+        let mut sig_callee2 = FunctionSignature::new();
+        sig_callee2
+            .global_parameters
+            .insert(1000, AccessPattern::new_unknown_access());
+        let mut fn_sigs = BTreeMap::from([
+            (Tid::new("main"), sig_main),
+            (Tid::new("callee1"), sig_callee1),
+            (Tid::new("callee2"), sig_callee2),
+        ]);
+
+        // Propagate globals
+        propagate_globals(&project, &mut fn_sigs);
+        // Check propagation results
+        assert_eq!(
+            &fn_sigs[&Tid::new("main")].global_parameters,
+            &HashMap::from([(1000, AccessPattern::new_unknown_access())])
+        );
+        assert_eq!(
+            &fn_sigs[&Tid::new("callee1")].global_parameters,
+            &HashMap::from([
+                (1000, AccessPattern::new_unknown_access()),
+                (2000, AccessPattern::new().with_dereference_flag())
+            ])
+        );
+        assert_eq!(
+            &fn_sigs[&Tid::new("callee2")].global_parameters,
+            &HashMap::from([(1000, AccessPattern::new_unknown_access())])
+        );
+    }
+}

--- a/src/cwe_checker_lib/src/analysis/function_signature/state/call_handling.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/state/call_handling.rs
@@ -152,7 +152,7 @@ impl State {
     }
 
     /// Return a list of all potential global memory addresses
-    /// for which any type of access has been tracked by the current state. 
+    /// for which any type of access has been tracked by the current state.
     pub fn get_global_mem_params_of_current_function(&self) -> Vec<(u64, AccessPattern)> {
         let mut global_params = Vec::new();
         for (id, access_pattern) in self.tracked_ids.iter() {
@@ -160,7 +160,7 @@ impl State {
                 match id.get_location() {
                     AbstractLocation::GlobalPointer(address, _)
                     | AbstractLocation::GlobalAddress { address, .. } => {
-                        global_params.push((*address, access_pattern.clone()));
+                        global_params.push((*address, *access_pattern));
                     }
                     AbstractLocation::Pointer(_, _) | AbstractLocation::Register(_) => (),
                 }

--- a/src/cwe_checker_lib/src/analysis/function_signature/state/call_handling.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/state/call_handling.rs
@@ -10,8 +10,9 @@ impl State {
         call_tid: &Tid,
         extern_symbol: &ExternSymbol,
         calling_convention: &CallingConvention,
+        global_memory: &RuntimeMemoryImage,
     ) {
-        let input_ids = self.collect_input_ids_of_call(&extern_symbol.parameters);
+        let input_ids = self.collect_input_ids_of_call(&extern_symbol.parameters, global_memory);
         self.clear_non_callee_saved_register(&calling_convention.callee_saved_register);
         self.generate_return_values_for_call(&input_ids, &extern_symbol.return_values, call_tid);
     }
@@ -26,6 +27,7 @@ impl State {
         &mut self,
         call: &Term<Jmp>,
         calling_convention: &CallingConvention,
+        global_memory: &RuntimeMemoryImage,
     ) {
         let mut parameters =
             generate_args_from_registers(&calling_convention.integer_parameter_register);
@@ -43,22 +45,24 @@ impl State {
                 data_type: None,
             });
         }
-        let input_ids = self.collect_input_ids_of_call(&parameters);
+        let input_ids = self.collect_input_ids_of_call(&parameters, global_memory);
         self.clear_non_callee_saved_register(&calling_convention.callee_saved_register);
         self.generate_return_values_for_call(&input_ids, &return_register, &call.tid);
     }
 
     /// Get all input IDs referenced in the parameters of a call.
-    /// Marks every input ID as accessed (with access flags for unknown access)
-    /// and generates stack parameter IDs for the current function if necessary.
-    fn collect_input_ids_of_call(&mut self, parameters: &[Arg]) -> BTreeSet<AbstractIdentifier> {
+    /// Marks every input ID as accessed (with access flags for unknown access).
+    /// Also generates stack parameter IDs and global memory IDs for the current function if necessary.
+    fn collect_input_ids_of_call(
+        &mut self,
+        parameters: &[Arg],
+        global_memory: &RuntimeMemoryImage,
+    ) -> BTreeSet<AbstractIdentifier> {
         let mut input_ids = BTreeSet::new();
         for input_param in parameters {
-            for (id, offset) in self
-                .eval_parameter_arg(input_param)
-                .get_relative_values()
-                .iter()
-            {
+            let param = self.eval_parameter_arg(input_param);
+            let param = self.substitute_global_mem_address(param, global_memory);
+            for (id, offset) in param.get_relative_values() {
                 input_ids.insert(id.clone());
                 // If the relative value points to the stack we also have to collect all IDs contained in the pointed-to value.
                 if *id == self.stack_id {
@@ -131,18 +135,38 @@ impl State {
         let mut params = Vec::new();
         for (id, access_pattern) in self.tracked_ids.iter() {
             if id.get_tid() == self.get_current_function_tid() {
-                if access_pattern.is_accessed() {
-                    params.push((generate_arg_from_abstract_id(id), *access_pattern));
-                } else if matches!(id.get_location(), &AbstractLocation::Pointer { .. }) {
-                    // This is a stack parameter.
-                    // If it was only loaded into a register but otherwise not used, then the read-flag needs to be set.
-                    let mut access_pattern = *access_pattern;
-                    access_pattern.set_read_flag();
-                    params.push((generate_arg_from_abstract_id(id), access_pattern));
+                if let Ok(param_arg) = generate_param_arg_from_abstract_id(id) {
+                    if access_pattern.is_accessed() {
+                        params.push((param_arg, *access_pattern));
+                    } else if matches!(id.get_location(), &AbstractLocation::Pointer { .. }) {
+                        // This is a stack parameter.
+                        // If it was only loaded into a register but otherwise not used, then the read-flag needs to be set.
+                        let mut access_pattern = *access_pattern;
+                        access_pattern.set_read_flag();
+                        params.push((param_arg, access_pattern));
+                    }
                 }
             }
         }
         params
+    }
+
+    /// Return a list of all potential global memory addresses
+    /// for which any type of access has been tracked by the current state. 
+    pub fn get_global_mem_params_of_current_function(&self) -> Vec<(u64, AccessPattern)> {
+        let mut global_params = Vec::new();
+        for (id, access_pattern) in self.tracked_ids.iter() {
+            if id.get_tid() == self.get_current_function_tid() && access_pattern.is_accessed() {
+                match id.get_location() {
+                    AbstractLocation::GlobalPointer(address, _)
+                    | AbstractLocation::GlobalAddress { address, .. } => {
+                        global_params.push((*address, access_pattern.clone()));
+                    }
+                    AbstractLocation::Pointer(_, _) | AbstractLocation::Register(_) => (),
+                }
+            }
+        }
+        global_params
     }
 
     /// Merges the access patterns of callee parameters with those of the caller (represented by `self`).
@@ -151,9 +175,15 @@ impl State {
     /// If a parameter is a pointer to the stack frame of self, it is dereferenced
     /// to set the access patterns of the target.
     /// Note that this may create new stack parameter objects for self.
-    pub fn merge_parameter_access(&mut self, params: &[(Arg, AccessPattern)]) {
+    pub fn merge_parameter_access(
+        &mut self,
+        params: &[(Arg, AccessPattern)],
+        global_memory: &RuntimeMemoryImage,
+    ) {
         for (parameter, call_access_pattern) in params {
-            for (id, offset) in self.eval_parameter_arg(parameter).get_relative_values() {
+            let param_value = self.eval_parameter_arg(parameter);
+            let param_value = self.substitute_global_mem_address(param_value, global_memory);
+            for (id, offset) in param_value.get_relative_values() {
                 if let Some(object) = self.tracked_ids.get_mut(id) {
                     *object = object.merge(call_access_pattern);
                 }
@@ -188,7 +218,7 @@ impl State {
     /// then return an argument object corresponding to the parameter.
     pub fn get_arg_corresponding_to_id(&self, id: &AbstractIdentifier) -> Option<Arg> {
         if id.get_tid() == self.stack_id.get_tid() {
-            Some(generate_arg_from_abstract_id(id))
+            generate_param_arg_from_abstract_id(id).ok()
         } else {
             None
         }
@@ -205,19 +235,23 @@ fn generate_args_from_registers(registers: &[Variable]) -> Vec<Arg> {
 
 /// Generate an argument representing the location in the given abstract ID.
 /// If the location is a pointer, it is assumed that the pointer points to the stack.
-/// Panics if the location contains a second level of indirection.
-fn generate_arg_from_abstract_id(id: &AbstractIdentifier) -> Arg {
+/// Returns an error if the location contains a second level of indirection
+/// or if the location is associated to global memory.
+fn generate_param_arg_from_abstract_id(id: &AbstractIdentifier) -> Result<Arg, Error> {
     match id.get_location() {
-        AbstractLocation::Register(var) => Arg::from_var(var.clone(), None),
+        AbstractLocation::Register(var) => Ok(Arg::from_var(var.clone(), None)),
         AbstractLocation::Pointer(var, mem_location) => match mem_location {
-            AbstractMemoryLocation::Location { offset, size } => Arg::Stack {
+            AbstractMemoryLocation::Location { offset, size } => Ok(Arg::Stack {
                 address: Expression::Var(var.clone()).plus_const(*offset),
                 size: *size,
                 data_type: None,
-            },
+            }),
             AbstractMemoryLocation::Pointer { .. } => {
-                panic!("Memory location is not a stack offset.")
+                Err(anyhow!("Memory location is not a stack offset."))
             }
         },
+        AbstractLocation::GlobalAddress { .. } | AbstractLocation::GlobalPointer(_, _) => {
+            Err(anyhow!("Global values are not parameters."))
+        }
     }
 }

--- a/src/cwe_checker_lib/src/analysis/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/mod.rs
@@ -2,6 +2,7 @@
 //! as well as analyses depending on these modules.
 
 pub mod backward_interprocedural_fixpoint;
+pub mod callgraph;
 pub mod dead_variable_elimination;
 pub mod fixpoint;
 pub mod forward_interprocedural_fixpoint;

--- a/src/cwe_checker_lib/src/intermediate_representation/expression.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/expression.rs
@@ -361,7 +361,7 @@ impl Expression {
             }
         } else if output_base_register.is_some() {
             self.piece_two_expressions_together(
-                *output_base_register.unwrap(),
+                output_base_register.unwrap(),
                 sub_register.unwrap(),
             );
         }

--- a/src/cwe_checker_lib/src/intermediate_representation/jmp.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/jmp.rs
@@ -92,3 +92,23 @@ impl fmt::Display for Jmp {
         }
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    impl Jmp {
+        /// Create a mock call to a TID with the given `target` and `return_`
+        /// as the names of the target and return TIDs.
+        pub fn mock_call(target: &str, return_: Option<&str>) -> Term<Jmp> {
+            let call = Jmp::Call {
+                target: Tid::new(target.to_string()),
+                return_: return_.map(|tid_name| Tid::new(tid_name)),
+            };
+            Term {
+                tid: Tid::new(format!("call_{}", target.to_string())),
+                term: call,
+            }
+        }
+    }
+}


### PR DESCRIPTION
The function signature analysis now tracks accesses to global memory, i.e. it generates information on which global variables are accessed by each function. The implementation is geared towards usage with other bottom-up analyses. Note that the generated information about global variables is not yet used by any analysis. It is planned to use this information in the pointer inference analysis in the future.