### PR TITLE
fix format string parsing bug

### DIFF
--- a/src/cwe_checker_lib/src/utils/arguments.rs
+++ b/src/cwe_checker_lib/src/utils/arguments.rs
@@ -57,7 +57,14 @@ pub fn parse_format_string_parameters(
     format_string: &str,
     datatype_properties: &DatatypeProperties,
 ) -> Result<Vec<(Datatype, ByteSize)>, Error> {
-    let re = Regex::new(r#"%\d{0,2}(([c,C,d,i,o,u,x,X,e,E,f,F,g,G,a,A,n,p,s,S])|(hi|hd|hu|li|ld|lu|lli|lld|llu|lf|lg|le|la|lF|lG|lE|lA|Lf|Lg|Le|La|LF|LG|LE|LA))"#)
+    // Regex parts:
+    // - `%` starts a format string parameter
+    // - `[+\-#0]{0,1}` matches the flags `+`, `-`, `#`, `0` if present (for printf-like functions)
+    // - `\d*` matches the width parameter
+    // - `[\.]?\d*` matches the precision parameter (for printf-like functions)
+    // - `[cCdiouxXeEfFgGaAnpsS]` matches a format specifier without length parameter.
+    // - `hi|hd|hu|li|ld|lu|lli|lld|llu|lf|lg|le|la|lF|lG|lE|lA|Lf|Lg|Le|La|LF|LG|LE|LA` matches format specifiers with length parameter.
+    let re = Regex::new(r#"%[+\-#0]{0,1}\d*[\.]?\d*([cCdiouxXeEfFgGaAnpsS]|hi|hd|hu|li|ld|lu|lli|lld|llu|lf|lg|le|la|lF|lG|lE|lA|Lf|Lg|Le|La|LF|LG|LE|LA)"#)
         .expect("No valid regex!");
 
     let datatype_map: Vec<(Datatype, ByteSize)> = re

--- a/src/cwe_checker_lib/src/utils/arguments/tests.rs
+++ b/src/cwe_checker_lib/src/utils/arguments/tests.rs
@@ -96,6 +96,34 @@ fn test_parse_format_string_destination_and_return_content() {
     );
 }
 
+/// Test the regular expression used for format string parameter parsing on specific cases.
+#[test]
+fn test_format_string_regex() {
+    let regex = Regex::new(r#"%[+\-#0]{0,1}\d*[\.]?\d*([cCdiouxXeEfFgGaAnpsS]|hi|hd|hu|li|ld|lu|lli|lld|llu|lf|lg|le|la|lF|lG|lE|lA|Lf|Lg|Le|La|LF|LG|LE|LA)"#)
+        .expect("No valid regex!");
+
+    let format_string = "one %s, two %.2lf%%, three %.2lf%%";
+    let results: Vec<_> = regex
+        .captures_iter(format_string)
+        .map(|cap| cap[1].to_string())
+        .collect();
+    assert_eq!(&results[..], vec!["s", "lf", "lf"]);
+
+    let format_string = "test %+2.300f,%-2.300f%#2.300f%02.300f";
+    let results: Vec<_> = regex
+        .captures_iter(format_string)
+        .map(|cap| cap[1].to_string())
+        .collect();
+    assert_eq!(&results[..], vec!["f", "f", "f", "f"]);
+
+    let format_string = r#"%cCd %ss %256s /dev/bus/usb/%03d/%s"#;
+    let results: Vec<_> = regex
+        .captures_iter(format_string)
+        .map(|cap| cap[1].to_string())
+        .collect();
+    assert_eq!(&results[..], vec!["c", "s", "s", "d", "s"]);
+}
+
 #[test]
 fn test_parse_format_string_parameters() {
     let test_cases: Vec<&str> = vec![


### PR DESCRIPTION
Improve the regular expression used for parsing C-like format string parameters. Fixes a bug where parsing of the format string `%s,` resulted in a crash.

Note that the improved regular expression is still not 100% exact as it may assume some malformed format string parameters to be correct. Please open an issue if you encounter a format string used in a real-world binary that is not parsed correctly.