### PR TITLE
Worklist order edit

### DIFF
--- a/src/cwe_checker_lib/src/analysis/backward_interprocedural_fixpoint/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/backward_interprocedural_fixpoint/mod.rs
@@ -257,6 +257,10 @@ pub fn create_computation<'a, T: Context<'a>>(
     super::fixpoint::Computation::new(generalized_problem, default_value.map(NodeValue::Value))
 }
 
+/// Generate a new computation from the corresponding context and an optional default value for nodes.
+/// Uses a bottom up worklist order when computing the fixpoint.
+///
+/// The worklist order prefers callee nodes before caller nodes.
 pub fn create_computation_with_bottom_up_worklist_order<'a, T: Context<'a>>(
     problem: T,
     default_value: Option<T::Value>,
@@ -270,6 +274,11 @@ pub fn create_computation_with_bottom_up_worklist_order<'a, T: Context<'a>>(
         priority_sorted_nodes,
     )
 }
+
+/// Generate a new computation from the corresponding context and an optional default value for nodes.
+/// Uses a top down worklist order when computing the fixpoint.
+///
+/// The worklist order prefers caller nodes before callee nodes.
 pub fn create_computation_with_top_down_worklist_order<'a, T: Context<'a>>(
     problem: T,
     default_value: Option<T::Value>,

--- a/src/cwe_checker_lib/src/analysis/backward_interprocedural_fixpoint/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/backward_interprocedural_fixpoint/mod.rs
@@ -11,6 +11,7 @@
 //! The `Computation` object provides the necessary methods for the actual fixpoint computation.
 
 use super::fixpoint::Context as GeneralFPContext;
+use super::forward_interprocedural_fixpoint;
 use super::graph::*;
 use super::interprocedural_fixpoint_generic::*;
 use crate::intermediate_representation::*;
@@ -254,6 +255,33 @@ pub fn create_computation<'a, T: Context<'a>>(
 ) -> super::fixpoint::Computation<GeneralizedContext<'a, T>> {
     let generalized_problem = GeneralizedContext::new(problem);
     super::fixpoint::Computation::new(generalized_problem, default_value.map(NodeValue::Value))
+}
+
+pub fn create_computation_with_bottom_up_worklist_order<'a, T: Context<'a>>(
+    problem: T,
+    default_value: Option<T::Value>,
+) -> super::fixpoint::Computation<GeneralizedContext<'a, T>> {
+    let priority_sorted_nodes =
+        forward_interprocedural_fixpoint::create_bottom_up_worklist(&problem.get_graph());
+    let generalized_problem = GeneralizedContext::new(problem);
+    super::fixpoint::Computation::from_node_priority_list(
+        generalized_problem,
+        default_value.map(NodeValue::Value),
+        priority_sorted_nodes,
+    )
+}
+pub fn create_computation_with_top_down_worklist_order<'a, T: Context<'a>>(
+    problem: T,
+    default_value: Option<T::Value>,
+) -> super::fixpoint::Computation<GeneralizedContext<'a, T>> {
+    let priority_sorted_nodes =
+        forward_interprocedural_fixpoint::create_top_down_worklist(&problem.get_graph());
+    let generalized_problem = GeneralizedContext::new(problem);
+    super::fixpoint::Computation::from_node_priority_list(
+        generalized_problem,
+        default_value.map(NodeValue::Value),
+        priority_sorted_nodes,
+    )
 }
 
 #[cfg(test)]

--- a/src/cwe_checker_lib/src/analysis/backward_interprocedural_fixpoint/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/backward_interprocedural_fixpoint/mod.rs
@@ -262,7 +262,7 @@ pub fn create_computation_with_bottom_up_worklist_order<'a, T: Context<'a>>(
     default_value: Option<T::Value>,
 ) -> super::fixpoint::Computation<GeneralizedContext<'a, T>> {
     let priority_sorted_nodes =
-        forward_interprocedural_fixpoint::create_bottom_up_worklist(&problem.get_graph());
+        forward_interprocedural_fixpoint::create_bottom_up_worklist(problem.get_graph());
     let generalized_problem = GeneralizedContext::new(problem);
     super::fixpoint::Computation::from_node_priority_list(
         generalized_problem,
@@ -275,7 +275,7 @@ pub fn create_computation_with_top_down_worklist_order<'a, T: Context<'a>>(
     default_value: Option<T::Value>,
 ) -> super::fixpoint::Computation<GeneralizedContext<'a, T>> {
     let priority_sorted_nodes =
-        forward_interprocedural_fixpoint::create_top_down_worklist(&problem.get_graph());
+        forward_interprocedural_fixpoint::create_top_down_worklist(problem.get_graph());
     let generalized_problem = GeneralizedContext::new(problem);
     super::fixpoint::Computation::from_node_priority_list(
         generalized_problem,

--- a/src/cwe_checker_lib/src/analysis/fixpoint.rs
+++ b/src/cwe_checker_lib/src/analysis/fixpoint.rs
@@ -113,7 +113,7 @@ impl<T: Context> Computation<T> {
     /// and the list of nodes of the graph ordered by the priority for the worklist algorithm.
     /// The worklist algorithm will try to stabilize the nodes with a higher index
     /// in the `priority_sorted_nodes` array before those with a lower index.
-    fn from_node_priority_list(
+    pub fn from_node_priority_list(
         fp_context: T,
         default_value: Option<T::NodeValue>,
         priority_sorted_nodes: Vec<NodeIndex>,

--- a/src/cwe_checker_lib/src/analysis/forward_interprocedural_fixpoint.rs
+++ b/src/cwe_checker_lib/src/analysis/forward_interprocedural_fixpoint.rs
@@ -296,7 +296,7 @@ pub fn create_computation_with_bottom_up_worklist_order<'a, T: Context<'a>>(
     problem: T,
     default_value: Option<T::Value>,
 ) -> super::fixpoint::Computation<GeneralizedContext<'a, T>> {
-    let priority_sorted_nodes: Vec<NodeIndex> = create_bottom_up_worklist(&problem.get_graph());
+    let priority_sorted_nodes: Vec<NodeIndex> = create_bottom_up_worklist(problem.get_graph());
     let generalized_problem = GeneralizedContext::new(problem);
     super::fixpoint::Computation::from_node_priority_list(
         generalized_problem,

--- a/src/cwe_checker_lib/src/analysis/forward_interprocedural_fixpoint.rs
+++ b/src/cwe_checker_lib/src/analysis/forward_interprocedural_fixpoint.rs
@@ -268,22 +268,6 @@ pub fn create_computation<'a, T: Context<'a>>(
     super::fixpoint::Computation::new(generalized_problem, default_value.map(NodeValue::Value))
 }
 
-/// Generate a new computation from the corresponding context and an optional default value for nodes.
-/// Uses the alternate worklist order when computing the fixpoint.
-///
-/// The alternate worklist order moves nodes with 10 or more incoming edges to the end of the priority queue.
-/// This can improve the convergence speed for these nodes in the fixpoint algorithm.
-/// Use if you encounter convergence problems for nodes with a lot of incoming edges.
-pub fn create_computation_with_alternate_worklist_order<'a, T: Context<'a>>(
-    problem: T,
-    default_value: Option<T::Value>,
-) -> super::fixpoint::Computation<GeneralizedContext<'a, T>> {
-    let generalized_problem = GeneralizedContext::new(problem);
-    super::fixpoint::Computation::new_with_alternate_worklist_order(
-        generalized_problem,
-        default_value.map(NodeValue::Value),
-    )
-}
 /// Returns a node ordering with callee nodes behind caller nodes.
 pub fn create_bottom_up_worklist(graph: &Graph) -> Vec<NodeIndex> {
     let mut graph = graph.clone();

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/mod.rs
@@ -108,7 +108,7 @@ impl<'a> PointerInference<'a> {
         let sub_to_entry_node_map = crate::analysis::graph::get_entry_nodes_of_subs(context.graph);
 
         let mut fixpoint_computation =
-            super::forward_interprocedural_fixpoint::create_computation_with_alternate_worklist_order(context, None);
+            super::forward_interprocedural_fixpoint::create_computation_with_bottom_up_worklist_order(context, None);
         if print_stats {
             let _ = log_sender.send(LogThreadMsg::Log(
                 LogMessage::new_info(format!(


### PR DESCRIPTION
Introduces a new worklist order for the forward interprocedural fixpoint computation. This order prefers nodes of callees and is verified by a test.