### PR TITLE
Implement global memory tracking for Pointer Inference

### DIFF
--- a/src/cwe_checker_lib/src/analysis/function_signature/global_var_propagation.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/global_var_propagation.rs
@@ -176,9 +176,7 @@ fn propagate_globals_bottom_up(
         let globals = fn_sig
             .global_parameters
             .iter()
-            .map(|(address, access_pattern)| {
-                (*address, *access_pattern)
-            })
+            .map(|(address, access_pattern)| (*address, *access_pattern))
             .collect();
         computation.set_node_value(node, globals);
     }

--- a/src/cwe_checker_lib/src/analysis/function_signature/global_var_propagation.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/global_var_propagation.rs
@@ -142,7 +142,7 @@ impl<'a> Context for GlobalsPropagationContext<'a> {
         let caller_globals: Self::NodeValue = callee_globals
             .iter()
             .filter_map(|(address, access_pattern)| {
-                if caller_known_globals.contains(address) && access_pattern.is_accessed() {
+                if caller_known_globals.contains(address) {
                     Some((*address, *access_pattern))
                 } else {
                     None
@@ -176,12 +176,8 @@ fn propagate_globals_bottom_up(
         let globals = fn_sig
             .global_parameters
             .iter()
-            .filter_map(|(address, access_pattern)| {
-                if access_pattern.is_accessed() {
-                    Some((*address, *access_pattern))
-                } else {
-                    None
-                }
+            .map(|(address, access_pattern)| {
+                (*address, *access_pattern)
             })
             .collect();
         computation.set_node_value(node, globals);

--- a/src/cwe_checker_lib/src/analysis/function_signature/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/mod.rs
@@ -75,12 +75,10 @@ fn generate_fixpoint_computation<'a>(
                         calling_convention,
                     );
                     if project.cpu_architecture.contains("MIPS") {
-                        let _ = fn_start_state.set_mips_link_register(&sub.tid, project.stack_pointer_register.size);
+                        let _ = fn_start_state
+                            .set_mips_link_register(&sub.tid, project.stack_pointer_register.size);
                     }
-                    computation.set_node_value(
-                        node,
-                        NodeValue::Value(fn_start_state),
-                    )
+                    computation.set_node_value(node, NodeValue::Value(fn_start_state))
                 }
             }
         }
@@ -281,7 +279,9 @@ pub mod tests {
     use super::*;
 
     impl FunctionSignature {
-        /// Create a mock x64 function signature with 2 parameters, one of which is accessed mutably.
+        /// Create a mock x64 function signature with 2 parameters, one of which is accessed mutably,
+        /// one mutably accessed global variable at address 0x2000
+        /// and one immutably accessed global variable at address 0x3000.
         pub fn mock_x64() -> FunctionSignature {
             let mut write_access_pattern = AccessPattern::new();
             write_access_pattern.set_unknown_access_flags();
@@ -297,7 +297,10 @@ pub mod tests {
             ]);
             FunctionSignature {
                 parameters,
-                global_parameters: HashMap::new(),
+                global_parameters: HashMap::from([
+                    (0x2000, AccessPattern::new_unknown_access()),
+                    (0x3000, AccessPattern::new().with_dereference_flag()),
+                ]),
             }
         }
     }

--- a/src/cwe_checker_lib/src/analysis/function_signature/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/mod.rs
@@ -69,13 +69,17 @@ fn generate_fixpoint_computation<'a>(
                                 .get_standard_calling_convention()
                                 .expect("No standard calling convention found.")
                         });
+                    let mut fn_start_state = State::new(
+                        &sub.tid,
+                        &project.stack_pointer_register,
+                        calling_convention,
+                    );
+                    if project.cpu_architecture.contains("MIPS") {
+                        let _ = fn_start_state.set_mips_link_register(&sub.tid, project.stack_pointer_register.size);
+                    }
                     computation.set_node_value(
                         node,
-                        NodeValue::Value(State::new(
-                            &sub.tid,
-                            &project.stack_pointer_register,
-                            calling_convention,
-                        )),
+                        NodeValue::Value(fn_start_state),
                     )
                 }
             }

--- a/src/cwe_checker_lib/src/analysis/function_signature/state/call_handling.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/state/call_handling.rs
@@ -156,7 +156,7 @@ impl State {
     pub fn get_global_mem_params_of_current_function(&self) -> Vec<(u64, AccessPattern)> {
         let mut global_params = Vec::new();
         for (id, access_pattern) in self.tracked_ids.iter() {
-            if id.get_tid() == self.get_current_function_tid() && access_pattern.is_accessed() {
+            if id.get_tid() == self.get_current_function_tid() {
                 match id.get_location() {
                     AbstractLocation::GlobalPointer(address, _)
                     | AbstractLocation::GlobalAddress { address, .. } => {

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/id_manipulation.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/id_manipulation.rs
@@ -49,6 +49,14 @@ impl<'a> Context<'a> {
             state_before_return.stack_id.clone(),
             Data::new_top(stack_register.size),
         );
+        // Also insert the global memory IDs to the map.
+        id_map.insert(
+            state_before_return.get_global_mem_id(),
+            Data::from_target(
+                state_before_call.get_global_mem_id(),
+                Bitvector::zero(stack_register.size.into()).into(),
+            ),
+        );
 
         id_map
     }

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/mod.rs
@@ -7,6 +7,7 @@ use crate::prelude::*;
 use crate::utils::log::*;
 use std::collections::{BTreeMap, BTreeSet};
 
+use super::object::AbstractObject;
 use super::state::State;
 use super::{Config, Data, VERSION};
 
@@ -294,6 +295,115 @@ impl<'a> Context<'a> {
             ),
         };
         let _ = self.log_collector.send(LogThreadMsg::Cwe(warning));
+    }
+
+    /// Merge global memory data from the callee global memory object to the caller global memory object
+    /// if the corresponding global variable is marked as mutable in both the caller and callee.
+    fn merge_global_mem_from_callee(
+        &self,
+        caller_state: &mut State,
+        callee_global_mem: &AbstractObject,
+        replacement_map: &BTreeMap<AbstractIdentifier, Data>,
+        callee_fn_sig: &FunctionSignature,
+        call_tid: &Tid,
+    ) {
+        let caller_global_mem_id = caller_state.get_global_mem_id();
+        let caller_fn_sig = self.fn_signatures.get(caller_state.get_fn_tid()).unwrap();
+        let caller_global_mem = caller_state
+            .memory
+            .get_object_mut(&caller_global_mem_id)
+            .unwrap();
+
+        // Get the intervals corresponding to global variables
+        // and the access pattern that denotes which globals should be overwritten by callee data.
+        let intervals =
+            compute_call_return_global_var_access_intervals(caller_fn_sig, callee_fn_sig);
+
+        let mut caller_mem_region = caller_global_mem.get_mem_region().clone();
+        mark_values_in_caller_global_mem_as_potentially_overwritten(
+            &mut caller_mem_region,
+            &intervals,
+        );
+
+        // Insert values from the callee into the memory object.
+        let mut referenced_ids = BTreeSet::new();
+        for (index, value) in callee_global_mem.get_mem_region().iter() {
+            if let Some((_interval_start, access_pattern)) =
+                intervals.range(..((*index + 1) as u64)).last()
+            {
+                if access_pattern.is_mutably_dereferenced() {
+                    let mut value = value.clone();
+                    value.replace_all_ids(replacement_map);
+                    referenced_ids.extend(value.referenced_ids().cloned());
+                    caller_mem_region.insert_at_byte_index(value, *index);
+                }
+            } else {
+                self.log_debug(
+                    Err(anyhow!("Unexpected occurrence of global variables.")),
+                    Some(call_tid),
+                );
+            }
+        }
+
+        caller_global_mem.overwrite_mem_region(caller_mem_region);
+        caller_global_mem.add_ids_to_pointer_targets(referenced_ids);
+    }
+}
+
+/// Generate a list of global indices as a union of the global indices known to caller and callee.
+/// The corresponding access patterns are mutably derefenced
+/// if and only if they are mutably dereferenced in both the caller and the callee.
+///
+/// Note that each index is supposed to denote the interval from that index until the next index in the map.
+/// This is a heuristic approximation, since we do not know the actual sizes of the global variables here.
+fn compute_call_return_global_var_access_intervals(
+    caller_fn_sig: &FunctionSignature,
+    callee_fn_sig: &FunctionSignature,
+) -> BTreeMap<u64, AccessPattern> {
+    let mut intervals: BTreeMap<u64, AccessPattern> = caller_fn_sig
+        .global_parameters
+        .keys()
+        .chain(callee_fn_sig.global_parameters.keys())
+        .map(|index| (*index, AccessPattern::new()))
+        .collect();
+    for (index, access_pattern) in intervals.iter_mut() {
+        if let (Some(caller_pattern), Some(callee_pattern)) = (
+            caller_fn_sig.global_parameters.get(index),
+            callee_fn_sig.global_parameters.get(index),
+        ) {
+            if caller_pattern.is_mutably_dereferenced() && callee_pattern.is_mutably_dereferenced()
+            {
+                access_pattern.set_mutably_dereferenced_flag();
+            }
+        }
+    }
+
+    intervals
+}
+
+/// Mark all values in the caller memory object representing global memory,
+/// that may have been overwritten by the callee, as potential `Top` values.
+fn mark_values_in_caller_global_mem_as_potentially_overwritten(
+    caller_global_mem_region: &mut MemRegion<Data>,
+    access_intervals: &BTreeMap<u64, AccessPattern>,
+) {
+    let mut interval_iter = access_intervals.iter().peekable();
+    while let Some((index, access_pattern)) = interval_iter.next() {
+        if access_pattern.is_mutably_dereferenced() {
+            if let Some((next_index, _next_pattern)) = interval_iter.peek() {
+                caller_global_mem_region.mark_interval_values_as_top(
+                    *index as i64,
+                    (**next_index - 1) as i64,
+                    ByteSize::new(1),
+                );
+            } else {
+                caller_global_mem_region.mark_interval_values_as_top(
+                    *index as i64,
+                    std::i64::MAX - 1,
+                    ByteSize::new(1),
+                );
+            }
+        }
     }
 }
 

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/trait_impls.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/trait_impls.rs
@@ -166,6 +166,20 @@ impl<'a> crate::analysis::forward_interprocedural_fixpoint::Context<'a> for Cont
                 // The callee stack frame does not exist anymore after return to the caller.
                 continue;
             }
+            if *callee_object_id == state_before_return.get_global_mem_id() {
+                let callee_fn_sig = self
+                    .fn_signatures
+                    .get(state_before_return.get_fn_tid())
+                    .unwrap();
+                self.merge_global_mem_from_callee(
+                    &mut state_after_return,
+                    callee_object,
+                    &id_map,
+                    callee_fn_sig,
+                    &call_term.tid,
+                );
+                continue;
+            }
             if Some(false)
                 == callee_id_to_access_pattern_map
                     .get(callee_object_id)

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/object/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/object/mod.rs
@@ -37,19 +37,21 @@ struct Inner {
     pointer_targets: BTreeSet<AbstractIdentifier>,
     /// Tracks whether this may represent more than one actual memory object.
     is_unique: bool,
-    /// Is the object a stack frame or a heap object
+    /// Is the object a stack frame, a heap object, or a global memory object.
     type_: Option<ObjectType>,
     /// The actual content of the memory object
     memory: MemRegion<Data>,
 }
 
-/// An object is either a stack or a heap object.
+/// An object can be a stack, a heap, or a global memory object.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy, PartialOrd, Ord)]
 pub enum ObjectType {
     /// A stack object, i.e. the stack frame of a function.
     Stack,
     /// A memory object located on the heap.
     Heap,
+    /// A memory oject indicating the global memory space.
+    GlobalMem,
 }
 
 #[allow(clippy::from_over_into)]
@@ -148,6 +150,24 @@ impl AbstractObject {
         } else {
             inner.memory = MemRegion::new(inner.memory.get_address_bytesize());
         }
+    }
+
+    /// Get the memory region abstract domain associated to the memory object.
+    pub fn get_mem_region(&self) -> &MemRegion<Data> {
+        &self.inner.memory
+    }
+
+    /// Overwrite the memory region abstract domain associated to the memory object.
+    /// Note that this function does not update the list of known pointer targets accordingly!
+    pub fn overwrite_mem_region(&mut self, new_memory_region: MemRegion<Data>) {
+        let inner = Arc::make_mut(&mut self.inner);
+        inner.memory = new_memory_region;
+    }
+
+    /// Add IDs to the list of pointer targets for the memory object.
+    pub fn add_ids_to_pointer_targets(&mut self, mut ids_to_add: BTreeSet<AbstractIdentifier>) {
+        let inner = Arc::make_mut(&mut self.inner);
+        inner.pointer_targets.append(&mut ids_to_add);
     }
 }
 

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/object_list/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/object_list/mod.rs
@@ -20,17 +20,26 @@ pub struct AbstractObjectList {
 }
 
 impl AbstractObjectList {
-    /// Create a new abstract object list with just one abstract object corresponding to the stack.
+    /// Create a new abstract object list with one abstract object corresponding to the stack
+    /// and one abstract object corresponding to global memory
     ///
-    /// The offset into the stack object and the `upper_index_bound` of the stack object will be both set to zero.
+    /// The offset into the stack object will be set to zero.
     /// This corresponds to the generic stack state at the start of a function.
     pub fn from_stack_id(
         stack_id: AbstractIdentifier,
         address_bytesize: ByteSize,
     ) -> AbstractObjectList {
-        let mut objects = BTreeMap::new();
         let stack_object = AbstractObject::new(Some(ObjectType::Stack), address_bytesize);
-        objects.insert(stack_id, stack_object);
+        let global_mem_id = AbstractIdentifier::new(
+            stack_id.get_tid().clone(),
+            AbstractLocation::GlobalAddress {
+                address: 0,
+                size: address_bytesize,
+            },
+        );
+        let global_mem_object = AbstractObject::new(Some(ObjectType::GlobalMem), address_bytesize);
+        let objects =
+            BTreeMap::from([(stack_id, stack_object), (global_mem_id, global_mem_object)]);
         AbstractObjectList { objects }
     }
 

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/statistics.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/statistics.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::abstract_domain::TryToBitvec;
+use crate::abstract_domain::{TryToBitvec, TryToInterval};
 use crossbeam_channel::Sender;
 
 /// Compute various statistics about how exact memory accesses through `Load` and `Store` instructions are tracked.
@@ -14,9 +14,15 @@ struct MemAccessStats {
     contains_top_flag: u64,
     empty_errors: u64,
     is_only_top: u64,
+
     global_mem_access: u64,
+    global_mem_ro_access: u64,
+    global_mem_writeable_access: u64,
+    global_mem_error_write_access: u64,
+    global_mem_interval_error: u64,
+
     current_stack_access: u64,
-    non_current_stack_access: u64,
+    other_mem_object_access: u64,
     exact_target_with_exact_offset: u64,
     exact_target_with_top_offset: u64,
 }
@@ -27,7 +33,7 @@ impl MemAccessStats {
     }
 
     fn ops_with_exact_target_known(&self) -> u64 {
-        self.global_mem_access + self.current_stack_access + self.non_current_stack_access
+        self.global_mem_access + self.current_stack_access + self.other_mem_object_access
     }
 
     fn print_general_stats(&self, log_collector: Sender<LogThreadMsg>) {
@@ -37,12 +43,14 @@ impl MemAccessStats {
             \t{:.2}% tracked,\n\
             \t{:.2}% partially tracked,\n\
             \t{:.2}% untracked,\n\
-            \t{:.2}% errors.",
+            \t{:.2}% errors (empty value),\n\
+            \t{:.2}% errors (invalid global address, e.g. Null pointer dereference),",
             self.all_mem_ops,
             self.tracked_mem_ops() as f64 / all_mem_ops * 100.,
             self.contains_top_flag as f64 / all_mem_ops * 100.,
             self.is_only_top as f64 / all_mem_ops * 100.,
             self.empty_errors as f64 / all_mem_ops * 100.,
+            self.global_mem_interval_error as f64 / all_mem_ops * 100.,
         );
         let log_msg = LogMessage::new_info(msg).source("Pointer Inference");
         let _ = log_collector.send(LogThreadMsg::Log(log_msg));
@@ -53,15 +61,23 @@ impl MemAccessStats {
         let msg = format!(
             "{} ({:.2}%) memory operations with exactly known target. Of these are\n\
             \t{:.2}% global memory access,\n\
+            \t\t{:.2}% global read-only memory access,\n\
+            \t\t{:.2}% global writeable memory access,\n\
+            \t\t{:.2}% global writeable memory access (mishandled by analysis),\n\
             \t{:.2}% current stack access,\n\
-            \t{:.2}% other (heap or stack) access,\n\
+            \t{:.2}% access to memory of unknown type,\n\
             \t{:.2}% with constant offset,\n\
             \t{:.2}% with unknown offset.",
             self.ops_with_exact_target_known(),
             self.ops_with_exact_target_known() as f64 / all_mem_ops * 100.,
             self.global_mem_access as f64 / self.ops_with_exact_target_known() as f64 * 100.,
+            self.global_mem_ro_access as f64 / self.ops_with_exact_target_known() as f64 * 100.,
+            self.global_mem_writeable_access as f64 / self.ops_with_exact_target_known() as f64
+                * 100.,
+            self.global_mem_error_write_access as f64 / self.ops_with_exact_target_known() as f64
+                * 100.,
             self.current_stack_access as f64 / self.ops_with_exact_target_known() as f64 * 100.,
-            self.non_current_stack_access as f64 / self.ops_with_exact_target_known() as f64 * 100.,
+            self.other_mem_object_access as f64 / self.ops_with_exact_target_known() as f64 * 100.,
             self.exact_target_with_exact_offset as f64 / self.ops_with_exact_target_known() as f64
                 * 100.,
             self.exact_target_with_top_offset as f64 / self.ops_with_exact_target_known() as f64
@@ -71,7 +87,7 @@ impl MemAccessStats {
         let _ = log_collector.send(LogThreadMsg::Log(log_msg));
     }
 
-    fn count_for_def(&mut self, state: &State, def: &Term<Def>) {
+    fn count_for_def(&mut self, state: &State, def: &Term<Def>, global_mem: &RuntimeMemoryImage) {
         use crate::abstract_domain::AbstractDomain;
         match &def.term {
             Def::Load { address, .. } | Def::Store { address, .. } => {
@@ -88,16 +104,30 @@ impl MemAccessStats {
 
                 if let Some(offset) = address_val.get_if_absolute_value() {
                     self.global_mem_access += 1;
-                    if offset.try_to_bitvec().is_ok() {
+                    if let Ok((start_address, end_address)) = offset.try_to_offset_interval() {
                         self.exact_target_with_exact_offset += 1;
+                        if let Ok(true) = global_mem
+                            .is_interval_writeable(start_address as u64, end_address as u64)
+                        {
+                            self.global_mem_error_write_access += 1;
+                        } else if let Ok(true) = global_mem
+                            .is_interval_readable(start_address as u64, end_address as u64)
+                        {
+                            self.global_mem_ro_access += 1;
+                        } else {
+                            self.global_mem_interval_error += 1;
+                        }
                     } else if offset.is_top() {
                         self.exact_target_with_top_offset += 1;
                     }
                 } else if let Some((id, offset)) = address_val.get_if_unique_target() {
                     if *id == state.stack_id {
                         self.current_stack_access += 1;
+                    } else if *id == state.get_global_mem_id() {
+                        self.global_mem_access += 1;
+                        self.global_mem_writeable_access += 1;
                     } else {
-                        self.non_current_stack_access += 1;
+                        self.other_mem_object_access += 1;
                     }
                     if offset.try_to_bitvec().is_ok() {
                         self.exact_target_with_exact_offset += 1;
@@ -116,12 +146,13 @@ impl MemAccessStats {
         let mut stats = Self::default();
         let graph = pointer_inference.computation.get_graph();
         let context = pointer_inference.get_context();
+        let global_memory = &context.project.runtime_memory_image;
         for (node_id, node) in graph.node_references() {
             if let Node::BlkStart(block, _sub) = node {
                 if let Some(state) = pointer_inference.computation.get_node_value(node_id) {
                     let mut state = state.unwrap_value().clone();
                     for def in &block.term.defs {
-                        stats.count_for_def(&state, def);
+                        stats.count_for_def(&state, def, global_memory);
                         state = match context.update_def(&state, def) {
                             Some(new_state) => new_state,
                             None => break,

--- a/src/cwe_checker_lib/src/analysis/string_abstraction/state/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/string_abstraction/state/tests.rs
@@ -6,11 +6,15 @@ use crate::{
         string_abstraction::tests::mock_project_with_intraprocedural_control_flow,
     },
 };
+use std::collections::BTreeSet;
 
 impl<T: AbstractDomain + DomainInsertion + HasTop + Eq + From<String>> State<T> {
     pub fn mock_with_default_pi_state(current_sub: Term<Sub>) -> Self {
-        let pi_state =
-            PointerInferenceState::new(&Variable::mock("sp", 4 as u64), current_sub.tid.clone());
+        let pi_state = PointerInferenceState::new(
+            &Variable::mock("sp", 4 as u64),
+            current_sub.tid.clone(),
+            BTreeSet::new(),
+        );
         State {
             unassigned_return_pointer: HashSet::new(),
             variable_to_pointer_map: HashMap::new(),

--- a/src/cwe_checker_lib/src/checkers/cwe_119/context/tests.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_119/context/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::BTreeSet;
 
 impl<'a> Context<'a> {
     /// Create a mock context.
@@ -27,7 +28,8 @@ fn test_compute_size_value_of_malloc_like_call() {
     use crate::analysis::pointer_inference::State as PiState;
     let project = Project::mock_x64();
     let mut pi_results = PointerInference::mock(&project);
-    let mut malloc_state = PiState::new(&Variable::mock("RSP", 8), Tid::new("func"));
+    let mut malloc_state =
+        PiState::new(&Variable::mock("RSP", 8), Tid::new("func"), BTreeSet::new());
     malloc_state.set_register(&Variable::mock("RDI", 8), Bitvector::from_i64(3).into());
     *pi_results.get_mut_states_at_tids() = HashMap::from([(Tid::new("malloc_call"), malloc_state)]);
     let malloc_symbol = ExternSymbol::mock_x64("malloc");

--- a/src/cwe_checker_lib/src/checkers/cwe_416/state.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_416/state.rs
@@ -168,9 +168,9 @@ impl AbstractDomain for State {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::intermediate_representation::Variable;
-
     use super::*;
+    use crate::intermediate_representation::Variable;
+    use std::collections::BTreeSet;
 
     #[test]
     fn test_check_address_for_use_after_free() {
@@ -225,7 +225,7 @@ pub mod tests {
             AbstractIdentifier::mock("obj_id", "RAX", 8),
             Bitvector::from_i64(0).into(),
         );
-        let pi_state = PiState::new(&Variable::mock("RSP", 8), Tid::new("call"));
+        let pi_state = PiState::new(&Variable::mock("RSP", 8), Tid::new("call"), BTreeSet::new());
         // Check that the parameter is correctly marked as freed in the state.
         assert!(state
             .handle_param_of_free_call(&Tid::new("free_call"), &param, &pi_state)
@@ -251,7 +251,7 @@ pub mod tests {
             AbstractIdentifier::mock("callee_obj_tid", "RAX", 8),
             ObjectState::Dangling(Tid::new("free_tid")),
         );
-        let pi_state = PiState::new(&Variable::mock("RSP", 8), Tid::new("call"));
+        let pi_state = PiState::new(&Variable::mock("RSP", 8), Tid::new("call"), BTreeSet::new());
         let id_replacement_map = BTreeMap::from([(
             AbstractIdentifier::mock("callee_obj_tid", "RAX", 8),
             Data::from_target(

--- a/src/cwe_checker_lib/src/checkers/cwe_467.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_467.rs
@@ -27,6 +27,7 @@ use crate::prelude::*;
 use crate::utils::log::{CweWarning, LogMessage};
 use crate::utils::symbol_utils::{get_callsites, get_symbol_map};
 use crate::CweModule;
+use std::collections::BTreeSet;
 
 /// The module name and version
 pub static CWE_MODULE: CweModule = CweModule {
@@ -46,7 +47,7 @@ pub struct Config {
 /// assuming nothing is known about the state at the start of the block.
 fn compute_block_end_state(project: &Project, block: &Term<Blk>) -> State {
     let stack_register = &project.stack_pointer_register;
-    let mut state = State::new(stack_register, block.tid.clone());
+    let mut state = State::new(stack_register, block.tid.clone(), BTreeSet::new());
 
     for def in block.term.defs.iter() {
         match &def.term {

--- a/src/cwe_checker_lib/src/checkers/cwe_476/state.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_476/state.rs
@@ -376,6 +376,7 @@ mod tests {
     use super::*;
     use crate::abstract_domain::*;
     use crate::analysis::pointer_inference::ValueDomain;
+    use std::collections::BTreeSet;
 
     impl State {
         pub fn mock() -> State {
@@ -396,7 +397,8 @@ mod tests {
                 size: ByteSize::new(8),
                 data_type: None,
             };
-            let pi_state = PointerInferenceState::new(&register("RSP"), Tid::new("func"));
+            let pi_state =
+                PointerInferenceState::new(&register("RSP"), Tid::new("func"), BTreeSet::new());
             let symbol = ExternSymbol {
                 tid: Tid::new("extern_symbol".to_string()),
                 addresses: vec![],

--- a/src/cwe_checker_lib/src/checkers/cwe_560.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_560.rs
@@ -29,6 +29,7 @@ use crate::prelude::*;
 use crate::utils::log::{CweWarning, LogMessage};
 use crate::utils::symbol_utils::{get_callsites, get_symbol_map};
 use crate::CweModule;
+use std::collections::BTreeSet;
 
 /// The module name and version
 pub static CWE_MODULE: CweModule = CweModule {
@@ -51,7 +52,7 @@ fn get_umask_permission_arg(
     project: &Project,
 ) -> Result<u64, Error> {
     let stack_register = &project.stack_pointer_register;
-    let mut state = State::new(stack_register, block.tid.clone());
+    let mut state = State::new(stack_register, block.tid.clone(), BTreeSet::new());
 
     for def in block.term.defs.iter() {
         match &def.term {

--- a/src/cwe_checker_lib/src/utils/arguments/tests.rs
+++ b/src/cwe_checker_lib/src/utils/arguments/tests.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use crate::{
     abstract_domain::IntervalDomain,
     intermediate_representation::{Bitvector, Tid},
@@ -6,7 +8,11 @@ use crate::{
 use super::*;
 
 fn mock_pi_state() -> PointerInferenceState {
-    PointerInferenceState::new(&Variable::mock("RSP", 8 as u64), Tid::new("func"))
+    PointerInferenceState::new(
+        &Variable::mock("RSP", 8 as u64),
+        Tid::new("func"),
+        BTreeSet::new(),
+    )
 }
 
 #[test]


### PR DESCRIPTION
Variables in mutable global memory are now also tracked by the Pointer Inference analysis.

Note that in the current implementation knowledge about global memory variables is only transmitted from callee to caller if the caller also accesses the same global variables in some way. Also, global variables are often used to transmit data between functions that are not in some caller-callee relationship, for which no data is shared between the functions in a bottom-up analysis anyway. So, the current implementation will mostly help with keeping track of global variables on an intraprocedural level, while interprocedural data sharing about global variables is possible, but wil not happen very often.