### PR TITLE
switch to Ghidra 10.2

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  GHIDRA_RELEASE_TAG: Ghidra_10.1.5_build
-  GHIDRA_VERSION: ghidra_10.1.5_PUBLIC_20220726
+  GHIDRA_RELEASE_TAG: Ghidra_10.2.2_build
+  GHIDRA_VERSION: ghidra_10.2.2_PUBLIC_20221115
 
 jobs: 
  
@@ -25,7 +25,7 @@ jobs:
           docker run --rm -v $(pwd)/build:/home/cwe/artificial_samples/build cross_compiling sudo python3 -m SCons
       - uses: actions/setup-java@v1
         with:
-          java-version: "11.0.x"
+          java-version: "17.0.x"
           java-package: jdk
           architecture: x64
       - name: Install Ghidra

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /cwe_checker
 COPY . .
 RUN cargo build --release
 
-FROM fkiecad/ghidra_headless_base:10.1.2 as runtime
+FROM fkiecad/ghidra_headless_base:10.2.2 as runtime
 
 RUN apt-get -y update \
     && apt-get -y install sudo \

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The prebuilt Docker images on dockerhub are currently only x86-based.
 
 The following dependencies must be installed in order to build and install the *cwe_checker* locally:
 -   [Rust](https://www.rust-lang.org) >= 1.63
--   [Ghidra](https://ghidra-sre.org/) >= 10.1.2
+-   [Ghidra](https://ghidra-sre.org/) >= 10.2 (**Warning:** This applies to the master branch, the v0.6 stable release needs Ghidra 10.1.5)
 
 Run `make all GHIDRA_PATH=/path/to/ghidra_folder` (with the correct path to the local Ghidra installation inserted) to compile and install the cwe_checker.
 If you omit the `GHIDRA_PATH` argument the installer will search your file system for a local installation of Ghidra.

--- a/src/cwe_checker_lib/src/abstract_domain/interval/simple_interval.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/simple_interval.rs
@@ -538,7 +538,7 @@ fn compute_intersection_residue_class(
     // ```
     let (gcd, left_inverse, right_inverse) = extended_gcd(stride_left, stride_right);
 
-    if base_left as i128 % gcd != base_right as i128 % gcd {
+    if base_left % gcd != base_right % gcd {
         // The residue classes do not intersect, thus the intersection is empty.
         Ok(None)
     } else {

--- a/src/cwe_checker_lib/src/analysis/string_abstraction/state/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/string_abstraction/state/mod.rs
@@ -255,16 +255,9 @@ impl<T: AbstractDomain + DomainInsertion + HasTop + Eq + From<String>> State<T> 
 
     /// Returns a vector of all currently tracked pointers.
     pub fn collect_all_tracked_pointers(&self) -> Vec<DataDomain<IntervalDomain>> {
-        let mut pointers: Vec<DataDomain<IntervalDomain>> = self
-            .stack_offset_to_pointer_map
-            .iter()
-            .map(|(_, pointer)| pointer.clone())
-            .collect();
-        let mut var_pointers = self
-            .variable_to_pointer_map
-            .iter()
-            .map(|(_, pointer)| pointer.clone())
-            .collect();
+        let mut pointers: Vec<DataDomain<IntervalDomain>> =
+            self.stack_offset_to_pointer_map.values().cloned().collect();
+        let mut var_pointers = self.variable_to_pointer_map.values().cloned().collect();
         let mut unassigned_pointers: Vec<DataDomain<IntervalDomain>> =
             self.unassigned_return_pointer.iter().cloned().collect_vec();
         pointers.append(&mut var_pointers);

--- a/src/cwe_checker_lib/src/checkers/cwe_476.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_476.rs
@@ -121,7 +121,7 @@ pub fn check_cwe(
             _ => panic!(),
         };
     }
-    let cwe_warnings = cwe_warnings.into_iter().map(|(_, cwe)| cwe).collect();
+    let cwe_warnings = cwe_warnings.into_values().collect();
 
     (Vec::new(), cwe_warnings)
 }

--- a/src/cwe_checker_lib/src/checkers/cwe_78.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_78.rs
@@ -138,7 +138,7 @@ pub fn check_cwe(
         };
     }
 
-    let cwe_warnings = cwe_warnings.into_iter().map(|(_, cwe)| cwe).collect();
+    let cwe_warnings = cwe_warnings.into_values().collect();
     let log_messages = log_receiver.try_iter().collect();
 
     (log_messages, cwe_warnings)

--- a/src/cwe_checker_lib/src/pcode/term.rs
+++ b/src/cwe_checker_lib/src/pcode/term.rs
@@ -294,7 +294,7 @@ impl Blk {
                     };
                     if input.address.is_some() {
                         let temp_register_name = format!("$load_temp{}", index);
-                        let load_def = input.to_load_def(&temp_register_name, generic_pointer_size);
+                        let load_def = input.to_load_def(temp_register_name, generic_pointer_size);
                         *input = load_def.lhs.clone().unwrap();
                         refactored_defs.push(Term {
                             tid: jmp.tid.clone().with_id_suffix("_load"),

--- a/src/cwe_checker_lib/src/utils/log.rs
+++ b/src/cwe_checker_lib/src/utils/log.rs
@@ -377,10 +377,7 @@ impl LogThread {
             .cloned()
             .chain(general_logs.into_iter())
             .collect();
-        let cwes = collected_cwes
-            .into_iter()
-            .map(|(_key, value)| value)
-            .collect();
+        let cwes = collected_cwes.into_values().collect();
         (logs, cwes)
     }
 }

--- a/src/ghidra/p_code_extractor/internal/HelperFunctions.java
+++ b/src/ghidra/p_code_extractor/internal/HelperFunctions.java
@@ -261,7 +261,7 @@ public final class HelperFunctions {
             regProps.add(
                 new RegisterProperties(reg.getName(), 
                                        reg.getBaseRegister().getName(), 
-                                       (int)(reg.getLeastSignificatBitInBaseRegister() / 8),
+                                       (int)(reg.getLeastSignificantBitInBaseRegister() / 8),
                                        context.getRegisterVarnode(reg).getSize())
             );
         }

--- a/src/installer/src/main.rs
+++ b/src/installer/src/main.rs
@@ -82,8 +82,7 @@ fn get_search_locations() -> Vec<PathBuf> {
 fn find_ghidra() -> Result<PathBuf> {
     let mut ghidra_locations: Vec<PathBuf> = get_search_locations()
         .into_iter()
-        .map(|x| search_for_ghidrarun(&x))
-        .flatten()
+        .flat_map(|x| search_for_ghidrarun(&x))
         .collect();
 
     ghidra_locations.sort();
@@ -98,7 +97,10 @@ fn find_ghidra() -> Result<PathBuf> {
 
 /// check whether a path starts with ".", indicating a hidden file or folder on Linux.
 fn is_hidden(path: &walkdir::DirEntry) -> bool {
-    path.file_name().to_str().map(|s| s.starts_with(".")).unwrap_or(false)
+    path.file_name()
+        .to_str()
+        .map(|s| s.starts_with('.'))
+        .unwrap_or(false)
 }
 
 /// Searches for a file containing "ghidraRun" at provided path recursively.

--- a/src/installer/src/main.rs
+++ b/src/installer/src/main.rs
@@ -82,7 +82,8 @@ fn get_search_locations() -> Vec<PathBuf> {
 fn find_ghidra() -> Result<PathBuf> {
     let mut ghidra_locations: Vec<PathBuf> = get_search_locations()
         .into_iter()
-        .filter_map(|x| search_for_ghidrarun(&x))
+        .map(|x| search_for_ghidrarun(&x))
+        .flatten()
         .collect();
 
     ghidra_locations.sort();
@@ -95,20 +96,28 @@ fn find_ghidra() -> Result<PathBuf> {
     }
 }
 
+/// check whether a path starts with ".", indicating a hidden file or folder on Linux.
+fn is_hidden(path: &walkdir::DirEntry) -> bool {
+    path.file_name().to_str().map(|s| s.starts_with(".")).unwrap_or(false)
+}
+
 /// Searches for a file containing "ghidraRun" at provided path recursively.
-fn search_for_ghidrarun(entry_path: &Path) -> Option<PathBuf> {
+fn search_for_ghidrarun(entry_path: &Path) -> Vec<PathBuf> {
+    let mut hits = Vec::new();
     for entry in WalkDir::new(entry_path)
+        .max_depth(8)
         .into_iter()
+        .filter_entry(|e| !is_hidden(e))
         .filter_map(|e| e.ok())
         .filter(|e| e.metadata().unwrap().is_file())
     {
         if entry.file_name().to_str().unwrap() == "ghidraRun" {
             let mut hit = entry.into_path();
             hit.pop();
-            return Some(hit);
+            hits.push(hit);
         }
     }
-    None
+    hits
 }
 
 /// Determines if a path is a ghidra installation

--- a/src/installer/src/main.rs
+++ b/src/installer/src/main.rs
@@ -34,7 +34,7 @@ struct GhidraConfig {
 fn copy_config_json(location: &Path) -> Result<()> {
     let repo_dir = env::current_dir().unwrap();
     std::fs::copy(
-        &repo_dir.join("src/config.json"),
+        repo_dir.join("src/config.json"),
         location.join("config.json"),
     )?;
     Ok(())


### PR DESCRIPTION
Ghidra 10.2 fixed a typo in a function name in its API. This is now also fixed in the corresponding script of the cwe_checker. Unfortunately, this makes it a breaking change, i.e. now the cwe_checker requires Ghidra versions >= 10.2, while older cwe_checker versions do not work with Ghidra 10.2.

For users of the Docker images this should be a painless transition, while users of a local installation need to update their Ghidra installations manually and explicitly execute `make uninstall` before reinstalling the cwe_checker.

The PR also includes slight improvements to the installer, so that several Ghidra installation folders in the same parent folder are found when scanning for Ghidra versions.