### PR TITLE
fixed bug of stack_alignment_substitution analysis

### DIFF
--- a/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/mod.rs
@@ -10,6 +10,8 @@
 //! - the argument for the AND operation is not a constant
 //! - an operation alters the stack pointer, which can not be journaled.
 
+use std::collections::HashSet;
+
 use anyhow::{anyhow, Result};
 use apint::ApInt;
 use itertools::Itertools;
@@ -98,28 +100,38 @@ fn get_first_branch_tid(blk: &Term<Blk>) -> Option<&Tid> {
 
 /// Returns the index of the first block with non-empty defs.
 /// Blocks are iterated according by considering their first `Jmp::Branch`.
-#[allow(clippy::never_loop, unused_assignments)]
+/// If a block is revisited, `None` is returned.
 fn get_first_blk_with_defs(sub: &Sub) -> Option<usize> {
     let blocks = &sub.blocks;
     if let Some(start_blk) = blocks.first() {
+        let mut visited = HashSet::new();
         let mut blk = start_blk;
-        while blk.term.defs.is_empty() {
+
+        'search_loop: while blk.term.defs.is_empty() {
             if let Some(target_tid) = get_first_branch_tid(blk) {
-                // try find this target
-                for (index, target_blk) in blocks.iter().enumerate() {
-                    if &target_blk.tid == target_tid {
-                        if !target_blk.term.defs.is_empty() {
-                            return Some(index);
-                        } else {
-                            // continue with new block
-                            blk = target_blk;
+                if !visited.contains(&blk.tid) {
+                    visited.insert(&blk.tid);
+
+                    // try find this target
+                    for (index, target_blk) in blocks.iter().enumerate() {
+                        if &target_blk.tid == target_tid {
+                            if !target_blk.term.defs.is_empty() {
+                                return Some(index);
+                            } else {
+                                // continue with new block
+                                blk = target_blk;
+                                continue 'search_loop;
+                            }
                         }
                     }
+                    // did not find target
+                    return None;
+                } else {
+                    // busy loop
+                    return None;
                 }
-                // did not find target
-                return None;
             } else {
-                // did not find Branch in Block
+                // did not find branch in block
                 return None;
             }
         }

--- a/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/mod.rs
@@ -90,7 +90,7 @@ fn journal_sp_value(
 
 /// Returns the tid of the target of the first Jmp::Branch of the provided block.
 fn get_first_branch_tid(blk: &Term<Blk>) -> Option<&Tid> {
-    for jmp in &blk.term.jmps {
+    if let Some(jmp) = blk.term.jmps.get(0) {
         if let Jmp::Branch(jump_to_blk) = &jmp.term {
             return Some(jump_to_blk);
         }

--- a/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/tests.rs
@@ -410,18 +410,24 @@ fn skips_empty_blocks() {
     );
     // get project with empty block
     let mut proj = setup(vec![], true);
-    let blk = setup(
-        vec![sub_from_sp.clone(), byte_alignment_as_and.clone()],
-        true,
-    )
-    .program
-    .term
-    .subs
-    .get(&Tid::new("sub_tid"))
-    .unwrap()
-    .term
-    .blocks[0]
-        .clone();
+    // add jmp
+    proj.program
+        .term
+        .subs
+        .get_mut(&Tid::new("sub_tid"))
+        .unwrap()
+        .term
+        .blocks[0]
+        .term
+        .jmps
+        .push(Term {
+            tid: Tid::new("tid"),
+            term: Jmp::Branch(Tid::new("not_empty_blk")),
+        });
+
+    let mut blk = Blk::mock_with_tid("not_empty_blk");
+    blk.term.defs.push(sub_from_sp.clone());
+    blk.term.defs.push(byte_alignment_as_and.clone());
 
     // add block with substitutional def
     proj.program

--- a/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/tests.rs
@@ -382,3 +382,78 @@ fn supports_commutative_and() {
         }
     }
 }
+#[test]
+/// Some functions have leading blocks without any defs. This might be due to `endbr`-like instructions.
+/// We skip those empty blocks and start substituting for rhe first non-empty block.
+fn skips_empty_blocks() {
+    let sub_from_sp = Def::assign(
+        "tid_alter_sp",
+        Project::mock_x64().stack_pointer_register.clone(),
+        Expression::minus(
+            Expression::Var(Project::mock_x64().stack_pointer_register.clone()),
+            Expression::const_from_apint(ApInt::from_u64(1)),
+        ),
+    );
+
+    let byte_alignment_as_and = Def::assign(
+        "tid_to_be_substituted",
+        Project::mock_x64().stack_pointer_register.clone(),
+        Expression::BinOp {
+            op: BinOpType::IntAnd,
+            lhs: Box::new(Expression::Var(
+                Project::mock_x64().stack_pointer_register.clone(),
+            )),
+            rhs: Box::new(Expression::const_from_apint(ApInt::from_u64(
+                0xFFFFFFFF_FFFFFFFF << 4, // 16 Byte alignment
+            ))),
+        },
+    );
+    // get project with empty block
+    let mut proj = setup(vec![], true);
+    let blk = setup(
+        vec![sub_from_sp.clone(), byte_alignment_as_and.clone()],
+        true,
+    )
+    .program
+    .term
+    .subs
+    .get(&Tid::new("sub_tid"))
+    .unwrap()
+    .term
+    .blocks[0]
+        .clone();
+
+    // add block with substitutional def
+    proj.program
+        .term
+        .subs
+        .get_mut(&Tid::new("sub_tid"))
+        .unwrap()
+        .term
+        .blocks
+        .push(blk);
+
+    let expected_def = Def::assign(
+        "tid_to_be_substituted",
+        Project::mock_x64().stack_pointer_register.clone(),
+        Expression::minus(
+            Expression::Var(Project::mock_x64().stack_pointer_register.clone()),
+            Expression::const_from_apint(ApInt::from_u64(15)),
+        ),
+    );
+
+    substitute_and_on_stackpointer(&mut proj);
+
+    assert_eq!(
+        proj.program
+            .term
+            .subs
+            .get(&Tid::new("sub_tid"))
+            .unwrap()
+            .term
+            .blocks[1]
+            .term
+            .defs,
+        vec![sub_from_sp.clone(), expected_def]
+    );
+}

--- a/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/stack_alignment_substitution/tests.rs
@@ -463,3 +463,31 @@ fn skips_empty_blocks() {
         vec![sub_from_sp.clone(), expected_def]
     );
 }
+
+#[test]
+fn skip_busy_loop() {
+    let mut proj = setup(vec![], true);
+    proj.program
+        .term
+        .subs
+        .get_mut(&Tid::new("sub_tid"))
+        .unwrap()
+        .term
+        .blocks[0]
+        .term
+        .jmps
+        .push(Jmp::branch("jmp_to_1st_blk", "block"));
+
+    assert_eq!(
+        get_first_blk_with_defs(
+            &proj
+                .program
+                .term
+                .subs
+                .get_mut(&Tid::new("sub_tid"))
+                .unwrap()
+                .term
+        ),
+        None
+    );
+}


### PR DESCRIPTION
The stack_alignment_substitution-Analysis only considered the first block of every sub for replacing AND-Operations. If a sub has leading blocks without defs, this analysis does not alter the function at all.
Such empty blocks might be generated by `endbr`-like instructions, which sometimes are the first instructions of a function.

The analysis was edited and now skips leading, empty blocks of a function.