### PR TITLE
handle nameless registers in Ghidra

### DIFF
--- a/src/ghidra/p_code_extractor/internal/TermCreator.java
+++ b/src/ghidra/p_code_extractor/internal/TermCreator.java
@@ -189,8 +189,14 @@ public class TermCreator {
     public static Variable createVariable(Varnode node) {
         Variable var = new Variable();
         if (node.isRegister()) {
-            var.setName(HelperFunctions.context.getRegister(node).getName());
-            var.setIsVirtual(false);
+            if (HelperFunctions.context.getRegister(node) == null) {
+                // This is a workaround for nameless registers encountered in some Aarch64 binaries.
+                var.setName(String.format("$U{}_unnamed", node.getAddress().toString()));
+                var.setIsVirtual(true);
+            } else {
+                var.setName(HelperFunctions.context.getRegister(node).getName());
+                var.setIsVirtual(false);
+            }
         } else if (node.isUnique()) {
             var.setName(HelperFunctions.renameVirtualRegister(node.getAddress().toString()));
             var.setIsVirtual(true);


### PR DESCRIPTION
For some reason Ghidra generates register accesses for non-existing registers in some cases for Aarch64 binaries, which lead to crashes in the P-Code-Extractor component. These cases may be Ghidra errors (at least the generated P-Code looks nonsensical), but as a workaround they are now represented as virtual registers in the cwe_checker.