### PR TITLE
generate log messages for zero-sized allocations instead of CWE warnings

### DIFF
--- a/src/cwe_checker_lib/src/checkers/cwe_119/stubs.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_119/stubs.rs
@@ -155,7 +155,7 @@ impl<'a, 'b> ExternCallHandler<'a, 'b> {
     /// Compute the size of a buffer from a corresponding size value.
     /// Returns `None` if no absolute size value could be determined for any reason.
     ///
-    /// If a range of posible sizes is detected, use the smallest possible size,
+    /// If a range of possible sizes is detected, use the smallest possible size,
     /// as using larger sizes would lead to too many false positive CWE warnings.
     fn compute_buffer_size_from_data_domain(&self, size: Data) -> Option<ByteSize> {
         let size = self.context.recursively_substitute_param_values(&size);


### PR DESCRIPTION
The behavior of allocation functions like `malloc(size)` is usually implementation-specific if the size parameter is zero. However, these cases often resulted in false positive CWE-119 (buffer overflow) warnings. Now the CWE-119 check generates log messages for cases of zero-sized allocations, but does not assume that an actual heap object with size zero gets created. As a fallback, in cases where the minimum object size would be zero, the CWE-119 check now uses the maximum object size instead when looking for buffer overflows.