### PR TITLE
Update to Ghidra 10.2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /cwe_checker
 COPY . .
 RUN cargo build --release
 
-FROM fkiecad/ghidra_headless_base:10.2.2 as runtime
+FROM ghcr.io/fkie-cad/ghidra_headless_base:10.2.3 as runtime
 
 RUN apt-get -y update \
     && apt-get -y install sudo \


### PR DESCRIPTION
Update the Ghidra version contained in our Docker images to Ghidra 10.2.3. Also move the base image for the Docker image from Dockerhub to the Github container registry. 