### PR TITLE
Prevent panic on non-converging globals propagation

### DIFF
--- a/src/cwe_checker_lib/src/analysis/function_signature/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/mod.rs
@@ -168,7 +168,7 @@ pub fn compute_function_signatures<'a>(
         }
     }
     // Propagate globals in bottom-up direction in the call graph
-    propagate_globals(project, &mut fn_sig_map);
+    propagate_globals(project, &mut fn_sig_map, &mut logs);
 
     (fn_sig_map, logs)
 }


### PR DESCRIPTION
The globals propagation algorithm (part of the function signature computation) can apparently not converge in some rare cases. Now we generate an error-log-message when that happens instead of panicking outright.