### PR TITLE
prevent huge expressions during expression propagation

### DIFF
--- a/src/cwe_checker_lib/src/intermediate_representation/expression.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/expression.rs
@@ -208,6 +208,22 @@ impl Expression {
             }
         }
     }
+
+    /// Compute a recursion depth for the expression.
+    ///
+    /// Because of the recursive nature of the [Expression] type,
+    /// overly complex expressions are very costly to clone, which in turn can negatively affect some analyses.
+    /// The recursion depth measure can be used to detect and handle such cases.
+    pub fn recursion_depth(&self) -> u64 {
+        use Expression::*;
+        match self {
+            Const(_) | Unknown { .. } | Var(_) => 0,
+            Subpiece { arg, .. } | Cast { arg, .. } | UnOp { arg, .. } => arg.recursion_depth() + 1,
+            BinOp { lhs, rhs, .. } => {
+                std::cmp::max(lhs.recursion_depth(), rhs.recursion_depth()) + 1
+            }
+        }
+    }
 }
 
 impl fmt::Display for Expression {


### PR DESCRIPTION
In rare cases the expression propagation fixpoint algorithm used huge amounts of RAM and computation time due to very large expressions that needed to be cloned repeatedly. We now enforce a complexity limit for expressions to be propagated in the expression propagation to prevent this behavior.

Fixes #410.