### PR TITLE
support more allocation and deallocation functions

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -89,6 +89,15 @@
       ]
     ]
   },
+  "CWE416": {
+    "deallocation_symbols": [
+      "free",
+      "realloc",
+      "reallocarray",
+      "operator.delete",
+      "operator.delete[]"
+    ]
+  },
   "CWE426": {
     "_comment": "functions that change/drop privileges",
     "symbols": [
@@ -237,8 +246,11 @@
       "malloc",
       "calloc",
       "realloc",
+      "reallocarray",
       "xmalloc",
-      "strdup"
+      "strdup",
+      "operator.new",
+      "operator.new[]"
     ]
   },
   "StringAbstraction": {


### PR DESCRIPTION
We now support more allocation and deallocation symbols, like `realloc` and the C++ `new` and `delete` operators, in the `Memory` analysis and the CWE-119 and CWE-416-checks.

Also, the deallocation symbols for the CWE-416-check are now configurable in the `config.json`. This way you can, for example, disable the support for `realloc` if it leads to a large amount of false positive warnings on your binaries.