### PR TITLE
prepare v0.7 stable release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,20 @@
-0.7-dev
+0.7 (2023-06)
 ====
+
+-   Improve handling of conditional assignment assembly instructions (PR #337)
+-   Improved exactness of CWE-190 check (PR #336)
+-   Improved exactness of CWE-119 check (PRs #339, #399)
+-   Added stubs for common libC-functions to several analyses (PRs #342, #348)
+-   Added a check for CWE-789: Memory Allocation with Excessive Size Value (PR #347)
+-   Improved implementation of the expression propagation algorithm (PR #356)
+-   Implement tracking of variables in global memory for several analyses (PRs #358, #361)
+-   Generate call trace information in the JSON output of CWE-119-check results (PRs #365, #388)
+-   Add macros for simpler unit test generation, refactored unit tests (PRs #380, #386)
+-   Function signature analysis output now gets properly sanitized (PR #389)
+-   Migrate the official Docker images from Dockerhub to ghcr.io (PR #401)
+-   Improved support for MIPS (PR #404)
+-   Generate call trace information in the JSON output of CWE-416-check results (PR #408)
+-   Support more allocation/deallocation functions in the checks, e.g C++-new/delete (PR #414)
 
 0.6 (2022-06)
 ====

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,12 +1,13 @@
 # cwe_checker contributors
 
 -   [Thomas Barabosch](https://github.com/tbarabosch)
-    -   Original author
+    -   Original author, maintainer 2018-2019
 
 -   [Nils-Edvin Enkelmann](https://github.com/Enkelmann)
-    -   Current maintainer
+    -   Maintainer since 2020
 
 -   [Jörg Stucke](https://github.com/jstucke)
-    -   Docker container
 
 -   [Melvin Klimke](https://github.com/mellowCS)
+
+-   [Mauritz van den Bosch](https://github.com/m-rtz)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "cwe_checker"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "cwe_checker_lib"
-version = "0.7.0-dev"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "apint",
@@ -263,22 +263,23 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "4.0.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -345,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.5.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
+checksum = "f27c1b4369c2cd341b5de549380158b105a04c331be5db9110eef7b6d2742134"
 dependencies = [
  "log",
  "plain",
@@ -496,6 +497,12 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "petgraph"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-***Important note:*** We recently decided to migrate from Dockerhub to the Github container registry.
-If you are using our prebuilt Docker images, please remember to change the cwe_checker-image names from `fkiecad/cwe_checker` to `ghcr.io/fkie-cad/cwe_checker` in your scripts!
-
 <p align="center">
     <img src="doc/images/cwe_checker_logo.png" alt="cwe_checker logo" width="50%" height="50%"/>
 </p>
@@ -21,13 +18,13 @@ Its main focus are ELF binaries that are commonly found on Linux and Unix operat
 The cwe_checker uses [Ghidra](https://ghidra-sre.org/) to disassemble binaries into one common intermediate representation
 and implements its own analyses on this IR.
 Hence, the analyses can be run on most CPU architectures that Ghidra can disassemble,
-which makes the *cwe_checker* a valuable tool for firmware analysis.
+which makes the cwe_checker a valuable tool for firmware analysis.
 
 The following arguments should convince you to give *cwe_checker* a try:
 -  it is very easy to set up, just build the Docker container!
 -  it analyzes ELF binaries of several CPU architectures including x86, ARM, MIPS, and PPC
 -  it is extensible due to its plugin-based architecture
--  it is configureable, e.g. apply analyses to new APIs
+-  it is configurable, e.g. apply analyses to new APIs
 -  view results annotated in Ghidra
 -  cwe_checker can be integrated as a plugin into [FACT](https://github.com/fkie-cad/FACT_core)
 
@@ -42,7 +39,7 @@ The following arguments should convince you to give *cwe_checker* a try:
 The simplest way is to pull the latest Docker image from the [Github container registry](https://github.com/fkie-cad/cwe_checker/pkgs/container/cwe_checker):
 -   `docker pull ghcr.io/fkie-cad/cwe_checker:latest` yields an image based on the current master branch.
 -   `docker pull ghcr.io/fkie-cad/cwe_checker:stable` yields an image based on the latest stable release version.
--   `docker pull ghcr.io/fkie-cad/cwe_checker:v0.6` yields an image based on the v0.6 stable release version.
+-   `docker pull ghcr.io/fkie-cad/cwe_checker:v0.7` yields an image based on the v0.7 stable release version.
 However, it is recommended to switch to newer stable releases as soon as they get published, since improvements between stable versions can be quite significant.
 
 If you want to build the docker image yourself, just run
@@ -56,7 +53,7 @@ The prebuilt Docker images are currently only x86-based.
 
 The following dependencies must be installed in order to build and install the *cwe_checker* locally:
 -   [Rust](https://www.rust-lang.org) >= 1.69
--   [Ghidra](https://ghidra-sre.org/) >= 10.2 (**Warning:** This applies to the master branch, the v0.6 stable release needs Ghidra 10.1.5)
+-   [Ghidra](https://ghidra-sre.org/) >= 10.2
 
 Run `make all GHIDRA_PATH=/path/to/ghidra_folder` (with the correct path to the local Ghidra installation inserted) to compile and install the cwe_checker.
 If you omit the `GHIDRA_PATH` argument the installer will search your file system for a local installation of Ghidra.

--- a/src/caller/Cargo.toml
+++ b/src/caller/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cwe_checker"
-version = "0.7.0-dev"
+version = "0.7.0"
 authors = ["Nils-Edvin Enkelmann <nils-edvin.enkelmann@fkie.fraunhofer.de>"]
 edition = "2021"
 
@@ -8,5 +8,5 @@ edition = "2021"
 clap = { version = "4.0", features = ["derive"] }
 cwe_checker_lib = { path = "../cwe_checker_lib" }
 serde_json = "1.0"
-directories = "4.0.1"
+directories = "5.0.1"
 anyhow = "1.0"

--- a/src/cwe_checker_lib/Cargo.toml
+++ b/src/cwe_checker_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cwe_checker_lib"
-version = "0.7.0-dev"
+version = "0.7.0"
 authors = ["Nils-Edvin Enkelmann <nils-edvin.enkelmann@fkie.fraunhofer.de>"]
 edition = "2021"
 
@@ -15,8 +15,8 @@ fnv = "1.0" # a faster hash function for small keys like integers
 anyhow = "1.0" # for easy error types
 crossbeam-channel = "0.5.4"
 derive_more = "0.99"
-directories = "4.0.1"
-goblin = "0.5.1"
+directories = "5.0.1"
+goblin = "0.7.1"
 itertools = "0.10.3"
 gcd = "2.1.0"
 nix = "0.26.1"

--- a/src/cwe_checker_lib/src/lib.rs
+++ b/src/cwe_checker_lib/src/lib.rs
@@ -11,7 +11,7 @@ Currently its main focus are ELF binaries that are commonly found on Linux and U
 The cwe_checker uses [Ghidra](https://ghidra-sre.org/) to disassemble binaries into one common intermediate representation
 and implements its own analyses on this IR.
 Hence, the analyses can be run on most CPU architectures that Ghidra can disassemble,
-which makes the *cwe_checker* a valuable tool for firmware analysis.
+which makes the cwe_checker a valuable tool for firmware analysis.
 
 # Usage
 

--- a/src/installer/Cargo.toml
+++ b/src/installer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-directories = "4.0.1"
+directories = "5.0.1"
 walkdir = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Highlights of v0.7 compared to v0.6: One new check (CWE789: memory allocation with excessive size value) and many improvements under the hood, including generation of better meta-information in the CWE-warnings of the CWE-119 and CWE-416 checks.