### PR TITLE
Limit acceptance tests to PRs to the master branch

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
PRs to other branches than master usually are larger work-in-progress branches that are not expected to be able to run the acceptance test suite. So we do not run them for such PRs.