### PR TITLE
always enforce expression complexity limit

### DIFF
--- a/src/cwe_checker_lib/src/analysis/expression_propagation/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/expression_propagation/tests.rs
@@ -142,11 +142,7 @@ fn inter_block_propagation() {
                 variable!("X:8"),
                 expr!("-(42:4)").un_op(UnOpType::BoolNegate),
             ),
-            Def::assign(
-                "entry_jmp_def_2",
-                variable!("Z:8"),
-                expr!("-(42:4)").un_op(UnOpType::IntNegate),
-            )
+            Def::assign("entry_jmp_def_2", variable!("Z:8"), expr!("42:4"),)
         ]
     )
 }
@@ -290,11 +286,7 @@ fn expressions_inserted() {
                 variable!("X:8"),
                 expr!("-(42:4)").un_op(UnOpType::BoolNegate),
             ),
-            Def::assign(
-                "entry_jmp_def_2",
-                variable!("Z:8"),
-                expr!("-(42:4)").un_op(UnOpType::IntNegate)
-            )
+            Def::assign("entry_jmp_def_2", variable!("Z:8"), expr!("42:4"))
         ]
     );
     assert_eq!(

--- a/src/ghidra/p_code_extractor/internal/ParseCspecContent.java
+++ b/src/ghidra/p_code_extractor/internal/ParseCspecContent.java
@@ -165,7 +165,7 @@ public class ParseCspecContent {
         String languageId = program.getLanguageID().toString();
 
         if (processorDef.startsWith("AARCH64") && languageId.endsWith("AppleSilicon")) {
-            processorDef = "AppleSilicon.ldef";
+            processorDef = "AppleSilicon.ldefs";
         }
         if(processorDef.startsWith("MIPS") || processorDef.startsWith("AVR")) {
             processorDef = processorDef.toLowerCase();


### PR DESCRIPTION
The expression compexity limit during the expression propagation algorithm was not enforced during the final expression substitution step. This could lead to excessive RAM usage in rare cases.

This PR also fixes a typo in the previous PR #427.