### PR TITLE
refactor CWE-416 check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["src/cwe_checker_lib", "src/caller", "test", "src/installer"]
+resolver = "2"

--- a/src/cwe_checker_lib/src/checkers/cwe_416/context.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_416/context.rs
@@ -76,7 +76,7 @@ impl<'a> Context<'a> {
         state: &mut State,
         call_tid: &Tid,
         call_params: impl IntoIterator<Item = &'b Arg>,
-    ) -> Option<Vec<(AbstractIdentifier, Tid)>> {
+    ) -> Option<Vec<(AbstractIdentifier, Vec<Tid>)>> {
         let mut warnings = Vec::new();
         for arg in call_params {
             if let Some(arg_value) = self
@@ -174,7 +174,7 @@ impl<'a> Context<'a> {
         name: &str,
         description: String,
         location: &Tid,
-        warning_causes: Vec<(AbstractIdentifier, Tid)>,
+        warning_causes: Vec<(AbstractIdentifier, Vec<Tid>)>,
         root_function: &Tid,
     ) {
         let cwe_warning = CweWarning {


### PR DESCRIPTION
The Cwe-416 was refactored with two goals: First, simplify the code for finding paths to "free" sites. And second, rework the detection logic to prevent some CWE warnings overshadowing other warnings with clearly different root causes.