### PR TITLE
Reduce false positives in CWE-416 check

### DIFF
--- a/src/cwe_checker_lib/src/abstract_domain/identifier/mod.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/identifier/mod.rs
@@ -1,6 +1,7 @@
 use crate::intermediate_representation::*;
 use crate::prelude::*;
 use derive_more::Deref;
+use std::ops::Deref;
 use std::sync::Arc;
 
 mod location;
@@ -149,6 +150,24 @@ impl AbstractIdentifier {
     /// Get the bytesize of the value represented by the abstract ID.
     pub fn bytesize(&self) -> ByteSize {
         self.location.bytesize()
+    }
+
+    /// If the abstract location of `self` has a parent location
+    /// then return the ID one gets when replacing the abstract location in `self` with its parent location.
+    pub fn get_id_with_parent_location(
+        &self,
+        generic_pointer_size: ByteSize,
+    ) -> Option<AbstractIdentifier> {
+        if let Ok((parent_location, _)) = self.location.get_parent_location(generic_pointer_size) {
+            let id_data = AbstractIdentifierData {
+                time: self.deref().time.clone(),
+                location: parent_location,
+                path_hints: self.deref().path_hints.clone(),
+            };
+            Some(AbstractIdentifier(Arc::new(id_data)))
+        } else {
+            None
+        }
     }
 }
 

--- a/src/cwe_checker_lib/src/analysis/fixpoint.rs
+++ b/src/cwe_checker_lib/src/analysis/fixpoint.rs
@@ -234,6 +234,16 @@ impl<T: Context> Computation<T> {
         &self.node_values
     }
 
+    /// Get a mutable iterator over all node values.
+    /// Also add all nodes that have values to the worklist, because one can change all their values through the iterator.
+    pub fn node_values_mut(&mut self) -> impl Iterator<Item = &mut T::NodeValue> {
+        for node in self.node_values.keys() {
+            let priority = self.node_priority_list[node.index()];
+            self.worklist.insert(priority);
+        }
+        self.node_values.values_mut()
+    }
+
     /// Get a reference to the underlying graph
     pub fn get_graph(&self) -> &DiGraph<T::NodeLabel, T::EdgeLabel> {
         self.fp_context.get_graph()

--- a/src/cwe_checker_lib/src/analysis/function_signature/context/tests.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/context/tests.rs
@@ -68,6 +68,7 @@ fn test_call_stub_handling() {
         &Tid::new("func"),
         &project.stack_pointer_register,
         project.get_standard_calling_convention().unwrap(),
+        2,
     );
     let extern_symbol = ExternSymbol::mock_malloc_symbol_arm();
     let call_tid = Tid::new("call_malloc");
@@ -93,6 +94,7 @@ fn test_call_stub_handling() {
         &Tid::new("func"),
         &project.stack_pointer_register,
         project.get_standard_calling_convention().unwrap(),
+        2,
     );
     // Set the format string param register to a pointer to the string 'cat %s %s %s %s'.
     state.set_register(&variable!("r1:4"), bitvec!("0x6000:4").into());

--- a/src/cwe_checker_lib/src/analysis/function_signature/state/memory_handling.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/state/memory_handling.rs
@@ -1,5 +1,4 @@
 use super::State;
-use super::POINTER_RECURSION_DEPTH_LIMIT;
 use crate::abstract_domain::*;
 use crate::intermediate_representation::*;
 
@@ -48,7 +47,7 @@ impl State {
                 Err(_) => DataDomain::new_top(size),
             }
         } else if let (true, Ok(constant_offset)) = (
-            id.get_location().recursion_depth() < POINTER_RECURSION_DEPTH_LIMIT,
+            id.get_location().recursion_depth() < self.pointer_recursion_depth_limit,
             offset.try_to_offset(),
         ) {
             // Extend the abstract location string

--- a/src/cwe_checker_lib/src/checkers/cwe_416/mod.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_416/mod.rs
@@ -51,6 +51,9 @@
 //! This reduces false positives and duplicates, but may also result in some false negatives.
 //! - Objects freed in the same call where they are created are not marked as freed in the caller.
 //! This reduces false positives, but may also result in some false negatives.
+//! - Pointers to recursively defined data structures like linked lists are heuristically identified and ignored.
+//! This reduces false positives generated when such structures are recursively freed in a loop,
+//! but also prevents detection of bugs involving such pointers.
 
 use crate::abstract_domain::AbstractIdentifier;
 use crate::prelude::*;

--- a/src/cwe_checker_lib/src/checkers/cwe_416/mod.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_416/mod.rs
@@ -47,6 +47,10 @@
 //! - Memory objects not tracked by the Pointer Inference analysis or pointer targets missed by the Pointer Inference
 //! may lead to missed CWEs in this check.
 //! - Pointers freed by other operations than calls to the deallocation symbols contained in the config.json will be missed by the analysis.
+//! - Pointers freed and flagged in the same call are not marked as freed in the caller.
+//! This reduces false positives and duplicates, but may also result in some false negatives.
+//! - Objects freed in the same call where they are created are not marked as freed in the caller.
+//! This reduces false positives, but may also result in some false negatives.
 
 use crate::abstract_domain::AbstractIdentifier;
 use crate::prelude::*;

--- a/src/cwe_checker_lib/src/checkers/cwe_416/state.rs
+++ b/src/cwe_checker_lib/src/checkers/cwe_416/state.rs
@@ -4,7 +4,7 @@ use crate::{
     analysis::pointer_inference::Data,
     prelude::*,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// The state of a memory object for which at least one possible call to a `free`-like function was detected.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -159,6 +159,9 @@ impl State {
 
     /// All TIDs that the given `param` may point to are marked as freed, i.e. pointers to them are dangling.
     /// For each ID that was already marked as dangling return a string describing the root cause of a possible double free bug.
+    ///
+    /// The function heuristically detects IDs related to recursive data structures (e.g. linked lists).
+    /// Such IDs are ignored when marking objects as freed.
     pub fn handle_param_of_free_call(
         &mut self,
         call_tid: &Tid,
@@ -168,7 +171,9 @@ impl State {
         // FIXME: This function could also generate debug log messages whenever nonsensical information is detected.
         // E.g. stack frame IDs or non-zero ID offsets can be indicators of other bugs.
         let mut warnings = Vec::new();
-        for id in param.get_relative_values().keys() {
+        let generic_pointer_size = pi_state.stack_id.bytesize();
+        // Heuristically ignore recursive IDs
+        for id in get_non_recursive_ids(param, generic_pointer_size) {
             if let Some(warning_data) = self.mark_as_freed(id, vec![call_tid.clone()], pi_state) {
                 warnings.push(warning_data);
             }
@@ -182,6 +187,10 @@ impl State {
 
     /// Add objects that were freed in the callee of a function call to the list of dangling pointers of `self`.
     /// Note that this function does not check for double frees.
+    ///
+    /// The function heuristically detects when parameter values contain IDs
+    /// corresponding to recursive data structures (e.g. linked lists).
+    /// Such IDs are ignored, i.e. their object status is not transferred from the callee.
     pub fn collect_freed_objects_from_called_function(
         &mut self,
         state_before_return: &State,
@@ -189,15 +198,17 @@ impl State {
         call_tid: &Tid,
         pi_state: &PiState,
     ) {
+        let generic_pointer_size = pi_state.stack_id.bytesize();
         let call_tid_with_suffix = call_tid.clone().with_id_suffix("_param");
 
         for (callee_id, callee_object_state) in state_before_return.dangling_objects.iter() {
             if let Some(caller_value) = id_replacement_map.get(callee_id) {
-                for caller_id in caller_value.get_relative_values().keys() {
+                // Heuristically filter out recursive IDs
+                for caller_id in get_non_recursive_ids(caller_value, generic_pointer_size) {
                     if caller_id.get_tid() == call_tid
                         || caller_id.get_tid() == &call_tid_with_suffix
                     {
-                        // FIXME: We heuristically ignore free operations if the happen in the same call as the creation of the object.
+                        // FIXME: We heuristically ignore free operations if they happen in the same call as the creation of the object.
                         // This reduces false positives, but also produces false negatives for some returned dangling pointers.
                         continue;
                     }
@@ -289,10 +300,34 @@ impl State {
     }
 }
 
+/// Return the set of relative IDs contained in the input `data` after filtering out recursive IDs.
+///
+/// An ID is *recursive*, i.e. assumed to correspond to a recursive data structure like a linked list,
+/// if its parent abstract location is also contained as an ID in `data`
+/// or if some ID contained in `data` has this ID as its parent.
+fn get_non_recursive_ids(
+    data: &Data,
+    generic_pointer_size: ByteSize,
+) -> BTreeSet<&AbstractIdentifier> {
+    let ids: BTreeSet<_> = data.get_relative_values().keys().collect();
+    let mut filtered_ids = ids.clone();
+    for id in &ids {
+        if let Some(parent_id) = id.get_id_with_parent_location(generic_pointer_size) {
+            if ids.contains(&parent_id) {
+                filtered_ids.remove(*id);
+                filtered_ids.remove(&parent_id);
+            }
+        }
+    }
+    filtered_ids
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::{bitvec, intermediate_representation::parsing, variable};
+    use crate::{
+        abstract_domain::DataDomain, bitvec, intermediate_representation::parsing, variable,
+    };
     use std::collections::BTreeSet;
 
     #[test]
@@ -396,6 +431,36 @@ pub mod tests {
                 .get(&AbstractIdentifier::mock("caller_tid", "RBX", 8))
                 .unwrap(),
             &ObjectState::Dangling(vec![Tid::new("free_tid"), Tid::new("call_tid")])
+        );
+    }
+
+    #[test]
+    fn test_filtering_of_recursive_ids() {
+        let data = DataDomain::mock_from_target_map(BTreeMap::from([
+            (
+                AbstractIdentifier::mock_nested("time1", "r0:4", &[], 4),
+                bitvec!("0x0:4").into(),
+            ),
+            (
+                AbstractIdentifier::mock_nested("time1", "r0:4", &[0], 4),
+                bitvec!("0x0:4").into(),
+            ),
+            (
+                AbstractIdentifier::mock_nested("unique1", "r0:4", &[], 4),
+                bitvec!("0x0:4").into(),
+            ),
+            (
+                AbstractIdentifier::mock_nested("unique2", "r0:4", &[0], 4),
+                bitvec!("0x0:4").into(),
+            ),
+        ]));
+        let filtered_ids = get_non_recursive_ids(&data, ByteSize::new(4));
+        assert_eq!(
+            filtered_ids,
+            BTreeSet::from([
+                &AbstractIdentifier::mock_nested("unique1", "r0:4", &[], 4),
+                &AbstractIdentifier::mock_nested("unique2", "r0:4", &[0], 4)
+            ])
         );
     }
 }


### PR DESCRIPTION
Since tracking of nested parameter objects greatly increased the amount of tracked memory objects, it also greatly increased the amount of false positives found by the CWE-416 Use After Free check. This PR implements several heuristic mitigations designed to reduce the number of false positives found by the check:
- If an object gets freed in the same call as it was created, the `dangling` status of its pointer is not propagated to callers. A common pattern is to free freshly created objects on errors and return a null pointer instead. But the analysis cannot yet track the invariant that the pointer is only returned when it is not freed, so we have to handle this pattern heuristically.
- If an object gets freed and subsequently generates a Use After Free warning in the same call then the the fact that it was freed by the call is not propagated to the caller. This should reduce duplicate CWE warnings when objects get freed on error paths.
- The function signature analysis now should not generate a parameter for the first element in an array if the function loops over it. Thus the CWE-416 analysis also does not track these elements and does not generate false positive warnings if the elements of an array are freed in a loop.
- Free operations for recursive data structures like linked lists are heuristically identified and ignored by the analysis. This should prevent false positives for when such a data structure gets freed using a loop.