### PR TITLE
Bump minimal supported Rust version to 1.73

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.73 AS builder
+FROM rust:1.73-bullseye AS builder
 
 WORKDIR /cwe_checker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.70 AS builder
+FROM rust:1.73 AS builder
 
 WORKDIR /cwe_checker
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The prebuilt Docker images are currently only x86-based.
 ### Local installation ###
 
 The following dependencies must be installed in order to build and install the *cwe_checker* locally:
--   [Rust](https://www.rust-lang.org) >= 1.70
+-   [Rust](https://www.rust-lang.org) >= 1.73
 -   [Ghidra](https://ghidra-sre.org/) >= 10.2
 
 Run `make all GHIDRA_PATH=/path/to/ghidra_folder` (with the correct path to the local Ghidra installation inserted) to compile and install the cwe_checker.

--- a/src/caller/Cargo.toml
+++ b/src/caller/Cargo.toml
@@ -3,6 +3,7 @@ name = "cwe_checker"
 version = "0.8.0"
 authors = ["Nils-Edvin Enkelmann <firmware-security@fkie.fraunhofer.de>"]
 edition = "2021"
+rust-version = "1.73"
 
 [dependencies]
 clap = { version = "4.0.32", features = ["derive"] }

--- a/src/cwe_checker_lib/Cargo.toml
+++ b/src/cwe_checker_lib/Cargo.toml
@@ -3,6 +3,7 @@ name = "cwe_checker_lib"
 version = "0.8.0"
 authors = ["Nils-Edvin Enkelmann <firmware-security@fkie.fraunhofer.de>"]
 edition = "2021"
+rust-version = "1.73"
 
 [dependencies]
 apint = "0.2"

--- a/src/installer/Cargo.toml
+++ b/src/installer/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cwe_checker_install"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.73"
 
 [dependencies]
 directories = "5.0.1"


### PR DESCRIPTION
Also add minimal supported Rust version to `Cargo.toml` files.

Add the minimal supported Rust version to `Cargo.toml` files to fail the
build as early as possible if the used Rust version is too old.