### PR TITLE
Implement LZCOUNT P-Code operation

### DIFF
--- a/src/cwe_checker_lib/src/abstract_domain/bitvector.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/bitvector.rs
@@ -245,7 +245,16 @@ pub mod tests {
         assert_eq!(
             BitvectorDomain::Value(bitvec!("-1:4")).cast(PopCount, ByteSize::new(8)),
             bv(32)
-        )
+        );
+
+        assert_eq!(
+            BitvectorDomain::Value(bitvec!("-1:4")).cast(LzCount, ByteSize::new(8)),
+            bv(0)
+        );
+        assert_eq!(
+            BitvectorDomain::Value(bitvec!("0:4")).cast(LzCount, ByteSize::new(8)),
+            bv(32)
+        );
     }
 
     #[test]

--- a/src/cwe_checker_lib/src/abstract_domain/interval.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval.rs
@@ -674,8 +674,7 @@ impl RegisterDomain for IntervalDomain {
                     IntervalDomain::new(
                         Bitvector::zero(width.into()),
                         Bitvector::from_u64(self.bytesize().as_bit_length() as u64)
-                            .into_truncate(width)
-                            .unwrap(),
+                            .into_zero_resize(width),
                     )
                 }
             }
@@ -693,16 +692,14 @@ impl RegisterDomain for IntervalDomain {
                         IntervalDomain::new(
                             Bitvector::zero(width.into()),
                             Bitvector::from_u64(self.bytesize().as_bit_length() as u64)
-                                .into_truncate(width)
-                                .unwrap(),
+                                .into_zero_resize(width),
                         )
                     }
                 } else {
                     IntervalDomain::new(
                         Bitvector::zero(width.into()),
                         Bitvector::from_u64(self.bytesize().as_bit_length() as u64)
-                            .into_truncate(width)
-                            .unwrap(),
+                            .into_zero_resize(width),
                     )
                 }
             }

--- a/src/cwe_checker_lib/src/abstract_domain/interval.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval.rs
@@ -667,7 +667,7 @@ impl RegisterDomain for IntervalDomain {
                 self.clone().sign_extend(width)
             }
             Float2Float | Int2Float | Trunc => IntervalDomain::new_top(width),
-            PopCount => {
+            PopCount | LzCount => {
                 if let Ok(bitvec) = self.try_to_bitvec() {
                     bitvec.cast(kind, width).unwrap().into()
                 } else {

--- a/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
@@ -664,5 +664,11 @@ fn lzcount_op() {
     // Test result for non-exact interval
     let interval: IntervalDomain = Interval::mock(3, 53).with_stride(5).into();
     let result = interval.cast(CastOpType::LzCount, ByteSize::new(8));
+    assert_eq!(result, Interval::mock(58, 62).into());
+    let interval: IntervalDomain = Interval::mock(-1, 1).into();
+    let result = interval.cast(CastOpType::LzCount, ByteSize::new(8));
     assert_eq!(result, Interval::mock(0, 64).into());
+    let interval: IntervalDomain = Interval::mock(-10, -4).into();
+    let result = interval.cast(CastOpType::LzCount, ByteSize::new(8));
+    assert_eq!(result, Interval::mock(0, 0).into());
 }

--- a/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval/tests.rs
@@ -652,3 +652,17 @@ fn stride_rounding() {
     );
     assert_eq!(bitvec!("-123:1").round_down_to_stride_of(&interval), None);
 }
+
+#[test]
+fn lzcount_op() {
+    use super::RegisterDomain;
+    // Test exact computation
+    let interval: IntervalDomain = Interval::mock_i8(3, 3).into();
+    let result = interval.cast(CastOpType::LzCount, ByteSize::new(2));
+    assert_eq!(result, bitvec!("0x6:2").into()); // leading 6 bits of the 8-bit value are zeroes
+
+    // Test result for non-exact interval
+    let interval: IntervalDomain = Interval::mock(3, 53).with_stride(5).into();
+    let result = interval.cast(CastOpType::LzCount, ByteSize::new(8));
+    assert_eq!(result, Interval::mock(0, 64).into());
+}

--- a/src/cwe_checker_lib/src/abstract_domain/mod.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/mod.rs
@@ -129,7 +129,7 @@ pub trait TryToInterval {
     fn try_to_interval(&self) -> Result<Interval, Error>;
 
     /// If `self` represents an interval of absolute values (or can be widened to represent such an interval)
-    /// then return it as an interval of signed integers if the interval is bounded.
+    /// then return it as an interval of signed integers of the form `(start, end)` if the interval is bounded.
     /// Else return an error.
     /// Note that the conversion loses information about the bytesize of the values contained in the interval.
     fn try_to_offset_interval(&self) -> Result<(i64, i64), Error> {

--- a/src/cwe_checker_lib/src/intermediate_representation/bitvector.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/bitvector.rs
@@ -58,12 +58,12 @@ impl BitvectorExtended for Bitvector {
             CastOpType::Int2Float | CastOpType::Float2Float | CastOpType::Trunc => {
                 Err(anyhow!("Float operations not yet implemented"))
             }
-            CastOpType::PopCount => Ok(Bitvector::from_u64(self.count_ones() as u64)
-                .into_truncate(width)
-                .unwrap()),
-            CastOpType::LzCount => Ok(Bitvector::from_u64(self.leading_zeros() as u64)
-                .into_truncate(width)
-                .unwrap()),
+            CastOpType::PopCount => {
+                Ok(Bitvector::from_u64(self.count_ones() as u64).into_resize_unsigned(width))
+            }
+            CastOpType::LzCount => {
+                Ok(Bitvector::from_u64(self.leading_zeros() as u64).into_resize_unsigned(width))
+            }
         }
     }
 

--- a/src/cwe_checker_lib/src/intermediate_representation/bitvector.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/bitvector.rs
@@ -61,6 +61,9 @@ impl BitvectorExtended for Bitvector {
             CastOpType::PopCount => Ok(Bitvector::from_u64(self.count_ones() as u64)
                 .into_truncate(width)
                 .unwrap()),
+            CastOpType::LzCount => Ok(Bitvector::from_u64(self.leading_zeros() as u64)
+                .into_truncate(width)
+                .unwrap()),
         }
     }
 

--- a/src/cwe_checker_lib/src/intermediate_representation/expression.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/expression.rs
@@ -128,6 +128,7 @@ pub enum CastOpType {
     Float2Float,
     Trunc,
     PopCount,
+    LzCount,
 }
 
 /// The type/mnemonic of an unary operation

--- a/src/cwe_checker_lib/src/pcode/expressions.rs
+++ b/src/cwe_checker_lib/src/pcode/expressions.rs
@@ -164,7 +164,7 @@ impl From<Expression> for IrExpression {
     /// Cases where translation is not possible:
     /// - `LOAD` and `STORE`, since these are not expressions (they have side effects).
     /// - Expressions which store the size of their output in the output variable (to which we do not have access here).
-    /// These include `SUBPIECE`, `INT_ZEXT`, `INT_SEXT`, `INT2FLOAT`, `FLOAT2FLOAT`, `TRUNC` and `POPCOUNT`.
+    /// These include `SUBPIECE`, `INT_ZEXT`, `INT_SEXT`, `INT2FLOAT`, `FLOAT2FLOAT`, `TRUNC`, `LZCOUNT` and `POPCOUNT`.
     /// Translation of these expressions is handled explicitly during translation of `Def`.
     fn from(expr: Expression) -> IrExpression {
         use ExpressionType::*;
@@ -186,7 +186,7 @@ impl From<Expression> for IrExpression {
                 op: expr.mnemonic.into(),
                 arg: Box::new(expr.input0.unwrap().into()),
             },
-            INT_ZEXT | INT_SEXT | INT2FLOAT | FLOAT2FLOAT | TRUNC | POPCOUNT => panic!(),
+            INT_ZEXT | INT_SEXT | INT2FLOAT | FLOAT2FLOAT | TRUNC | POPCOUNT | LZCOUNT => panic!(),
         }
     }
 }
@@ -203,6 +203,7 @@ pub enum ExpressionType {
     PIECE,
     SUBPIECE,
     POPCOUNT,
+    LZCOUNT,
 
     INT_EQUAL,
     INT_NOTEQUAL,
@@ -353,6 +354,7 @@ impl From<ExpressionType> for IrCastOpType {
             FLOAT2FLOAT => IrCastOpType::Float2Float,
             TRUNC => IrCastOpType::Trunc,
             POPCOUNT => IrCastOpType::PopCount,
+            LZCOUNT => IrCastOpType::LzCount,
             _ => panic!(),
         }
     }

--- a/src/cwe_checker_lib/src/pcode/term.rs
+++ b/src/cwe_checker_lib/src/pcode/term.rs
@@ -166,7 +166,7 @@ impl Def {
                 size: target_var.size,
                 arg: Box::new(self.rhs.input0.unwrap().into()),
             },
-            INT_ZEXT | INT_SEXT | INT2FLOAT | FLOAT2FLOAT | TRUNC | POPCOUNT => {
+            INT_ZEXT | INT_SEXT | INT2FLOAT | FLOAT2FLOAT | TRUNC | POPCOUNT | LZCOUNT => {
                 IrExpression::Cast {
                     op: self.rhs.mnemonic.into(),
                     size: target_var.size,


### PR DESCRIPTION
Implement support for the LZCOUNT P-Code operation introduced in Ghidra 10.3.

This was originally meant to be implemented alongside a major refactoring of the P-Code parsing code. But since that refactoring will need longer than expected, we have to support it now so that we can keep up with newer Ghidra versions.