### PR TITLE
ir: impl `Display` for `Program`

### DIFF
--- a/src/cwe_checker_lib/src/intermediate_representation/blk.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/blk.rs
@@ -71,11 +71,11 @@ impl Term<Blk> {
 
 impl fmt::Display for Blk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for def in self.defs.iter() {
-            writeln!(f, "{}: {}", def.tid, def.term)?;
+        for Term { tid, term: def } in self.defs.iter() {
+            writeln!(f, "DEF [{}] {}", tid, def)?;
         }
-        for jmp in self.jmps.iter() {
-            writeln!(f, "{}: {}", jmp.tid, jmp.term)?;
+        for Term { tid, term: jmp } in self.jmps.iter() {
+            writeln!(f, "JMP [{}] {}", tid, jmp)?;
         }
         Ok(())
     }

--- a/src/cwe_checker_lib/src/intermediate_representation/program.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/program.rs
@@ -1,6 +1,7 @@
 use super::{Blk, ExternSymbol, Sub};
 use crate::prelude::*;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 
 /// The `Program` structure represents a disassembled binary.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -47,5 +48,36 @@ impl Program {
             }
         }
         None
+    }
+}
+
+impl fmt::Display for Program {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for Term { tid, term: sub } in self.subs.values() {
+            writeln!(
+                f,
+                "SUB [{}] n:{} e:{}",
+                tid,
+                sub.name,
+                if self.entry_points.contains(tid) {
+                    1
+                } else {
+                    0
+                }
+            )?;
+            for Term { tid, term: blk } in sub.blocks.iter() {
+                writeln!(f, "  BLK [{}]", tid)?;
+                for Term { tid, term: def } in blk.defs.iter() {
+                    writeln!(f, "    DEF [{}] {}", tid, def)?;
+                }
+                for Term { tid, term: jmp } in blk.jmps.iter() {
+                    writeln!(f, "    JMP [{}] {}", tid, jmp)?;
+                }
+            }
+        }
+        for ext in self.extern_symbols.values() {
+            writeln!(f, "EXT {}", ext)?;
+        }
+        Ok(())
     }
 }

--- a/src/cwe_checker_lib/src/intermediate_representation/program.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/program.rs
@@ -56,13 +56,13 @@ impl fmt::Display for Program {
         for Term { tid, term: sub } in self.subs.values() {
             writeln!(
                 f,
-                "SUB [{}] n:{} e:{}",
+                "SUB [{}] name:{} entry:{}",
                 tid,
                 sub.name,
                 if self.entry_points.contains(tid) {
-                    1
+                    "yes"
                 } else {
-                    0
+                    "no"
                 }
             )?;
             for Term { tid, term: blk } in sub.blocks.iter() {

--- a/src/cwe_checker_lib/src/intermediate_representation/sub.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/sub.rs
@@ -154,9 +154,9 @@ impl ExternSymbol {
 
 impl fmt::Display for ExternSymbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}] n:{}", self.tid, self.name)?;
+        write!(f, "[{}] name:{}", self.tid, self.name)?;
         for addr in self.addresses.iter() {
-            write!(f, " a:{}", addr)?;
+            write!(f, " address:{}", addr)?;
         }
         Ok(())
     }

--- a/src/cwe_checker_lib/src/intermediate_representation/sub.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/sub.rs
@@ -1,5 +1,6 @@
 use super::{Blk, Datatype, Expression, Project, Variable};
 use crate::prelude::*;
+use std::fmt;
 
 /// A `Sub` or subroutine represents a function with a given name and a list of basic blocks belonging to it.
 ///
@@ -148,6 +149,16 @@ impl ExternSymbol {
     /// Get the calling convention corresponding to the extern symbol.
     pub fn get_calling_convention<'a>(&self, project: &'a Project) -> &'a CallingConvention {
         project.get_calling_convention(self)
+    }
+}
+
+impl fmt::Display for ExternSymbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] n:{}", self.tid, self.name)?;
+        for addr in self.addresses.iter() {
+            write!(f, " a:{}", addr)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Implement the `Display` trait for the intermediate language representation of the analyzed program.

This outputs a human-friendly representation that is more compact than what is returned by `Debug` and is therefore easier to consume.

There are no direct users of this implementation, its main purpose is to facilitate easier debugging during development.

For example, the following C program becomes:
```C
int say_hello(char *msg)
{
    if (msg)
        printf("Hello, World: %s\n", msg);

    return 42;
}
```
```
[...]
SUB [sub_00101110] n:say_hello e:1
  BLK [blk_00101110]
    DEF [instr_00101110_0] CF:1 = 0x0:1
    DEF [instr_00101110_1] OF:1 = 0x0:1
    DEF [instr_00101110_2] $U56080:8(temp) = (RDI:8 & RDI:8)
    DEF [instr_00101110_3] SF:1 = ($U56080:8(temp) < 0x0:8)
    DEF [instr_00101110_4] ZF:1 = ($U56080:8(temp) == 0x0:8)
    DEF [instr_00101110_5] $U13400:8(temp) = ($U56080:8(temp) & 0xff:8)
    DEF [instr_00101110_6] $U13480:1(temp) = PopCount($U13400:8(temp))
    DEF [instr_00101110_7] $U13500:1(temp) = ($U13480:1(temp) & 0x1:1)
    DEF [instr_00101110_8] PF:1 = ($U13500:1(temp) == 0x0:1)
    JMP [instr_00101113_0] If ZF:1 jump to blk_00101138
    JMP [instr_00101113_1] Jump to blk_00101115
  BLK [blk_00101115]
    DEF [instr_00101115_0] CF:1 = (RSP:8 < 0x8:8)
    DEF [instr_00101115_1] OF:1 = (RSP:8 IntSBorrow 0x8:8)
    DEF [instr_00101115_2] RSP:8 = (RSP:8 - 0x8:8)
    DEF [instr_00101115_3] SF:1 = (RSP:8 < 0x0:8)
    DEF [instr_00101115_4] ZF:1 = (RSP:8 == 0x0:8)
    DEF [instr_00101115_5] $U13400:8(temp) = (RSP:8 & 0xff:8)
    DEF [instr_00101115_6] $U13480:1(temp) = PopCount($U13400:8(temp))
    DEF [instr_00101115_7] $U13500:1(temp) = ($U13480:1(temp) & 0x1:1)
    DEF [instr_00101115_8] PF:1 = ($U13500:1(temp) == 0x0:1)
    DEF [instr_00101119_0] RSI:8 = RDI:8
    DEF [instr_0010111c_0] RDI:8 = 0x102000:8
    DEF [instr_00101123_0] CF:1 = 0x0:1
    DEF [instr_00101123_1] OF:1 = 0x0:1
    DEF [instr_00101123_3] RAX:8 = IntZExt(((RAX:8)[0-3] ^ (RAX:8)[0-3]))
    DEF [instr_00101123_4] SF:1 = ((RAX:8)[0-3] < 0x0:4)
    DEF [instr_00101123_5] ZF:1 = ((RAX:8)[0-3] == 0x0:4)
    DEF [instr_00101123_6] $U13400:4(temp) = ((RAX:8)[0-3] & 0xff:4)
    DEF [instr_00101123_7] $U13480:1(temp) = PopCount($U13400:4(temp))
    DEF [instr_00101123_8] $U13500:1(temp) = ($U13480:1(temp) & 0x1:1)
    DEF [instr_00101123_9] PF:1 = ($U13500:1(temp) == 0x0:1)
    DEF [instr_00101125_0] RSP:8 = (RSP:8 - 0x8:8)
    DEF [instr_00101125_1] Store at RSP:8 := 0x10112a:8
    JMP [instr_00101125_2] call sub_00101030 ret blk_0010112a
  BLK [blk_0010112a]
    DEF [instr_0010112a_0] RAX:8 = 0x2a:8
    DEF [instr_0010112f_0] CF:1 = (RSP:8 IntCarry 0x8:8)
    DEF [instr_0010112f_1] OF:1 = (RSP:8 IntSCarry 0x8:8)
    DEF [instr_0010112f_2] RSP:8 = (RSP:8 + 0x8:8)
    DEF [instr_0010112f_3] SF:1 = (RSP:8 < 0x0:8)
    DEF [instr_0010112f_4] ZF:1 = (RSP:8 == 0x0:8)
    DEF [instr_0010112f_5] $U13400:8(temp) = (RSP:8 & 0xff:8)
    DEF [instr_0010112f_6] $U13480:1(temp) = PopCount($U13400:8(temp))
    DEF [instr_0010112f_7] $U13500:1(temp) = ($U13480:1(temp) & 0x1:1)
    DEF [instr_0010112f_8] PF:1 = ($U13500:1(temp) == 0x0:1)
    DEF [instr_00101133_0] RIP:8 := Load from RSP:8
    DEF [instr_00101133_1] RSP:8 = (RSP:8 + 0x8:8)
    JMP [instr_00101133_2] ret RIP:8
  BLK [blk_00101138]
    DEF [instr_00101138_0] RAX:8 = 0x2a:8
    DEF [instr_0010113d_0] RIP:8 := Load from RSP:8
    DEF [instr_0010113d_1] RSP:8 = (RSP:8 + 0x8:8)
    JMP [instr_0010113d_2] ret RIP:8
[...]
EXT [sub_00101030] n:printf a:00105008 a:00101030
```