### PR TITLE
update Ghidra version in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /cwe_checker
 COPY . .
 RUN cargo build --release
 
-FROM ghcr.io/fkie-cad/ghidra_headless_base:10.2.3 as runtime
+FROM ghcr.io/fkie-cad/ghidra_headless_base:11.0.1 as runtime
 
 RUN apt-get -y update \
     && apt-get -y install sudo \


### PR DESCRIPTION
Update the Ghidra version used in the Docker image to the newest Ghidra release.