### PR TITLE
Revert "update Ghidra version in Docker image (#448)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /cwe_checker
 COPY . .
 RUN cargo build --release
 
-FROM ghcr.io/fkie-cad/ghidra_headless_base:11.0.1 as runtime
+FROM ghcr.io/fkie-cad/ghidra_headless_base:10.2.3 as runtime
 
 RUN apt-get -y update \
     && apt-get -y install sudo \


### PR DESCRIPTION
This reverts commit 71eea8d715082af622db4bc160590311975e9939.

Problems were discovered with the PcodeExtractor plugin for Ghidra 11+. Until the problems are fixed, go back to the previous version.