### PR TITLE
docker/lkm_samples: do not install 'aptitude'

### DIFF
--- a/test/lkm_samples/Dockerfile
+++ b/test/lkm_samples/Dockerfile
@@ -13,7 +13,6 @@ RUN set -x && \
     apt-get update && \
     apt-get install -y -q apt-utils dialog && \
     apt-get install -y -q \
-	aptitude \
 	bc \
 	bison \
 	bsdmainutils \


### PR DESCRIPTION
We don't need it and it causes the CI to fail - two good reasons to get rid of it.