### PR TITLE
Clippy 1.78 fixes

### DIFF
--- a/src/cwe_checker_lib/src/abstract_domain/bricks.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/bricks.rs
@@ -144,7 +144,7 @@ impl BricksDomain {
             if lookup == normalized {
                 unchanged = true;
             } else {
-                lookup = normalized.clone();
+                lookup.clone_from(&normalized);
             }
         }
 

--- a/src/cwe_checker_lib/src/abstract_domain/mem_region.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/mem_region.rs
@@ -293,7 +293,7 @@ impl<T: AbstractDomain + SizedDomain + HasTop + std::fmt::Debug> MemRegion<T> {
             }
         }
         for (index, other_elem) in other.inner.values.iter() {
-            if self.inner.values.get(index).is_none() {
+            if !self.inner.values.contains_key(index) {
                 zipped.insert(*index, (None, Some(other_elem)));
             }
         }

--- a/src/cwe_checker_lib/src/analysis/dead_variable_elimination/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/dead_variable_elimination/mod.rs
@@ -99,7 +99,7 @@ fn remove_dead_var_assignments_of_block(
     let mut cleaned_defs = Vec::new();
     for def in block.term.defs.iter().rev() {
         match &def.term {
-            Def::Assign { var, .. } if alive_vars.get(var).is_none() => (), // Dead Assignment
+            Def::Assign { var, .. } if !alive_vars.contains(var) => (), // Dead Assignment
             _ => cleaned_defs.push(def.clone()),
         }
         alive_vars_computation::update_alive_vars_by_def(&mut alive_vars, def);

--- a/src/cwe_checker_lib/src/analysis/function_signature/context/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/function_signature/context/mod.rs
@@ -153,8 +153,7 @@ impl<'a> Context<'a> {
             }
             if self
                 .stubbed_variadic_symbols
-                .get(extern_symbol.name.as_str())
-                .is_some()
+                .contains_key(extern_symbol.name.as_str())
                 && self
                     .set_access_flags_for_variadic_parameters(state, extern_symbol)
                     .is_none()

--- a/src/cwe_checker_lib/src/analysis/graph.rs
+++ b/src/cwe_checker_lib/src/analysis/graph.rs
@@ -432,7 +432,7 @@ impl<'a> GraphBuilder<'a> {
         return_from_sub: &'a Term<Sub>,
         return_source: NodeIndex,
     ) {
-        if self.return_addresses.get(&return_from_sub.tid).is_none() {
+        if !self.return_addresses.contains_key(&return_from_sub.tid) {
             return;
         }
         for (call_node, return_to_node) in self.return_addresses[&return_from_sub.tid].iter() {

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/id_manipulation.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/id_manipulation.rs
@@ -150,8 +150,8 @@ impl<'a> Context<'a> {
                 .unwrap()
                 .referenced_ids()
             {
-                if ids_modified.get(id).is_some()
-                    || (access_pattern.is_mutably_dereferenced() && ids_touched.get(id).is_some())
+                if ids_modified.contains(id)
+                    || (access_pattern.is_mutably_dereferenced() && ids_touched.contains(id))
                 {
                     unsound_caller_ids.insert(id.clone());
                 }

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/trait_impls.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/trait_impls.rs
@@ -201,10 +201,7 @@ impl<'a> crate::analysis::forward_interprocedural_fixpoint::Context<'a> for Cont
             let mut callee_object = callee_object.clone();
             callee_object.replace_ids(&id_map);
 
-            if callee_id_to_access_pattern_map
-                .get(callee_object_id)
-                .is_none()
-            {
+            if !callee_id_to_access_pattern_map.contains_key(callee_object_id) {
                 // Add a callee object that does not correspond to a parameter to the caller or the stack of the callee.
                 state_after_return
                     .memory

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/state/id_manipulation.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/state/id_manipulation.rs
@@ -20,7 +20,7 @@ impl State {
             unsearched_ids.remove(&id);
             let memory_ids = self.memory.get_referenced_ids_underapproximation(&id);
             for mem_id in memory_ids {
-                if ids.get(&mem_id).is_none() {
+                if !ids.contains(&mem_id) {
                     ids.insert(mem_id.clone());
                     unsearched_ids.insert(mem_id.clone());
                 }
@@ -45,7 +45,7 @@ impl State {
             unsearched_ids.remove(&id);
             let memory_ids = self.memory.get_referenced_ids_overapproximation(&id);
             for mem_id in memory_ids {
-                if ids.get(&mem_id).is_none() {
+                if !ids.contains(&mem_id) {
                     ids.insert(mem_id.clone());
                     unsearched_ids.insert(mem_id.clone());
                 }

--- a/src/cwe_checker_lib/src/intermediate_representation/project/block_duplication_normalization.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/project/block_duplication_normalization.rs
@@ -77,20 +77,20 @@ impl Project {
                 sub.term.blocks.iter().map(|blk| blk.tid.clone()).collect();
             let mut block_set = HashSet::new();
             while let Some(block_tid) = worklist.pop() {
-                if block_set.get(&block_tid).is_none() {
+                if !block_set.contains(&block_tid) {
                     block_set.insert(block_tid.clone());
 
                     if let Some(block) = block_tid_to_block_map.get(&block_tid) {
                         for jmp in block.term.jmps.iter() {
                             if let Some(tid) = jmp.get_intraprocedural_target_or_return_block_tid()
                             {
-                                if block_set.get(&tid).is_none() {
+                                if !block_set.contains(&tid) {
                                     worklist.push(tid);
                                 }
                             }
                         }
                         for target_tid in block.term.indirect_jmp_targets.iter() {
-                            if block_set.get(target_tid).is_none() {
+                            if !block_set.contains(target_tid) {
                                 worklist.push(target_tid.clone())
                             }
                         }

--- a/src/cwe_checker_lib/src/pcode/term.rs
+++ b/src/cwe_checker_lib/src/pcode/term.rs
@@ -246,7 +246,7 @@ impl Blk {
             if let Some(input) = &def.term.rhs.input0 {
                 if input.address.is_some() {
                     let load_def = input.to_load_def("$load_temp0", generic_pointer_size);
-                    cleaned_def.term.rhs.input0 = load_def.lhs.clone();
+                    cleaned_def.term.rhs.input0.clone_from(&load_def.lhs);
                     refactored_defs.push(Term {
                         tid: def.tid.clone().with_id_suffix("_load0"),
                         term: load_def,
@@ -256,7 +256,7 @@ impl Blk {
             if let Some(input) = &def.term.rhs.input1 {
                 if input.address.is_some() {
                     let load_def = input.to_load_def("$load_temp1", generic_pointer_size);
-                    cleaned_def.term.rhs.input1 = load_def.lhs.clone();
+                    cleaned_def.term.rhs.input1.clone_from(&load_def.lhs);
                     refactored_defs.push(Term {
                         tid: def.tid.clone().with_id_suffix("_load1"),
                         term: load_def,
@@ -266,7 +266,7 @@ impl Blk {
             if let Some(input) = &def.term.rhs.input2 {
                 if input.address.is_some() {
                     let load_def = input.to_load_def("$load_temp2", generic_pointer_size);
-                    cleaned_def.term.rhs.input2 = load_def.lhs.clone();
+                    cleaned_def.term.rhs.input2.clone_from(&load_def.lhs);
                     refactored_defs.push(Term {
                         tid: def.tid.clone().with_id_suffix("_load2"),
                         term: load_def,

--- a/src/cwe_checker_lib/src/utils/graph_utils.rs
+++ b/src/cwe_checker_lib/src/utils/graph_utils.rs
@@ -48,7 +48,7 @@ pub fn is_sink_call_reachable_from_source_call(
                 | Edge::ReturnCombine(_)
                 | Edge::Jump(_, _)
                 | Edge::ExternCallStub(_) => {
-                    if visited_nodes.get(&edge.target()).is_none() {
+                    if !visited_nodes.contains(&edge.target()) {
                         visited_nodes.insert(edge.target());
                         worklist.push(edge.target())
                     }


### PR DESCRIPTION
The [latest Clippy update](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-178) introduced a few new lints. Fix warnings caused by [`assigning_clones`](https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones) and [`unnecessary_get_then_check`](https://rust-lang.github.io/rust-clippy/master/index.html#/unnecessary_get_then_check) s.t. CI passes again.