### PR TITLE
Issue 469: Semantically invalid IR statements due to bad Subregister Substitution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 0.9-dev
 ===
 
+-   Fixed an issue in the pcode to IR translation (PR #470)
 -   Added initial benchmarking infrastructure (PR #464)
 -   Improve Control Flow Propagation normalization pass (PR #462)
 -   Improve taint analysis abstraction to simplify interprocedural bottom-up

--- a/src/cwe_checker_lib/src/abstract_domain/data/arithmetics.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/data/arithmetics.rs
@@ -194,6 +194,12 @@ impl<T: RegisterDomain> RegisterDomain for DataDomain<T> {
 
     /// extract a sub-bitvector
     fn subpiece(&self, low_byte: ByteSize, size: ByteSize) -> Self {
+        // Extracting zero-sized subpieces is an semantically invalid operation.
+        debug_assert_ne!(
+            size,
+            ByteSize::new(0),
+            "Attempt to extract zero-sized subpiece."
+        );
         if low_byte == ByteSize::new(0) && size == self.bytesize() {
             // The operation is a no-op
             self.clone()

--- a/src/cwe_checker_lib/src/abstract_domain/interval.rs
+++ b/src/cwe_checker_lib/src/abstract_domain/interval.rs
@@ -292,7 +292,10 @@ impl IntervalDomain {
             interval,
             widening_lower_bound: lower_bound,
             widening_upper_bound: upper_bound,
-            widening_delay: self.widening_delay >> low_byte.as_bit_length(),
+            widening_delay: self
+                .widening_delay
+                .overflowing_shr(low_byte.as_bit_length() as u32)
+                .0,
         }
     }
 

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/context/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/context/mod.rs
@@ -435,7 +435,7 @@ fn mark_values_in_caller_global_mem_as_potentially_overwritten(
             } else {
                 caller_global_mem_region.mark_interval_values_as_top(
                     *index as i64,
-                    std::i64::MAX - 1,
+                    i64::MAX - 1,
                     ByteSize::new(1),
                 );
             }

--- a/src/cwe_checker_lib/src/analysis/pointer_inference/state/mod.rs
+++ b/src/cwe_checker_lib/src/analysis/pointer_inference/state/mod.rs
@@ -151,7 +151,7 @@ impl State {
                     self.store_value(
                         &Data::from_target(
                             parent_id,
-                            Bitvector::from_u64(address + offset as u64)
+                            Bitvector::from_u64(address.wrapping_add(offset as u64))
                                 .into_resize_signed(self.stack_id.bytesize())
                                 .into(),
                         ),

--- a/src/cwe_checker_lib/src/intermediate_representation/term/builder_low_lvl.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/term/builder_low_lvl.rs
@@ -13,14 +13,20 @@ use crate::{expr, intermediate_representation::*, variable};
 
 #[cfg(test)]
 impl Expression {
-    /// Shortcut for creating a cast expression
+    /// Shortcut for creating a cast expression.
     #[cfg(test)]
-    pub fn cast(self, op: CastOpType) -> Expression {
+    pub fn cast_to_size(self, op: CastOpType, result_size: ByteSize) -> Expression {
         Expression::Cast {
             op,
-            size: ByteSize::new(8),
+            size: result_size,
             arg: Box::new(self),
         }
+    }
+
+    /// Shortcut for creating a cast expression with target size 8.
+    #[cfg(test)]
+    pub fn cast(self, op: CastOpType) -> Expression {
+        self.cast_to_size(op, ByteSize::new(8))
     }
 
     /// Shortcut for creating a subpiece expression

--- a/src/cwe_checker_lib/src/pcode/subregister_substitution/tests.rs
+++ b/src/cwe_checker_lib/src/pcode/subregister_substitution/tests.rs
@@ -257,7 +257,7 @@ fn piecing_or_zero_extending() {
         tid: Tid::new("zext_ah_to_eax"),
         term: Def::Assign {
             var: variable!("EAX:4"),
-            value: Expression::cast(expr!("AH:1"), CastOpType::IntZExt),
+            value: Expression::cast_to_size(expr!("AH:1"), CastOpType::IntZExt, ByteSize::new(4)),
         },
     };
     let zext_ah_to_rax = Term {

--- a/src/cwe_checker_lib/src/pcode/term.rs
+++ b/src/cwe_checker_lib/src/pcode/term.rs
@@ -1,5 +1,4 @@
 use std::collections::{BTreeSet, HashMap};
-use std::usize;
 
 use super::subregister_substitution::replace_input_subregister;
 use super::{Expression, ExpressionType, RegisterProperties, Variable};

--- a/src/cwe_checker_lib/src/utils/debug.rs
+++ b/src/cwe_checker_lib/src/utils/debug.rs
@@ -4,6 +4,8 @@
 #![allow(dead_code)]
 #![allow(missing_docs)]
 
+use std::path::PathBuf;
+
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Default)]
 /// Stages of the analysis that can be debugged separately.
 #[non_exhaustive]
@@ -48,29 +50,60 @@ pub enum Verbosity {
 /// Selects whether the analysis is aborted after reaching the point of
 /// interest.
 #[non_exhaustive]
-enum TerminationPolicy {
+pub enum TerminationPolicy {
     KeepRunning,
     #[default]
     EarlyExit,
     Panic,
 }
 
-#[derive(PartialEq, Eq, Copy, Clone, Default, Debug)]
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
 /// Configuration of the debugging behavior.
 pub struct Settings {
     stage: Stage,
     verbose: Verbosity,
     terminate: TerminationPolicy,
+    saved_pcode_raw: Option<PathBuf>,
+}
+
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
+pub struct SettingsBuilder {
+    inner: Settings,
+}
+
+impl SettingsBuilder {
+    pub fn build(self) -> Settings {
+        self.inner
+    }
+
+    pub fn set_stage(mut self, stage: Stage) -> Self {
+        self.inner.stage = stage;
+
+        self
+    }
+
+    pub fn set_verbosity(mut self, verbosity: Verbosity) -> Self {
+        self.inner.verbose = verbosity;
+
+        self
+    }
+
+    pub fn set_termination_policy(mut self, policy: TerminationPolicy) -> Self {
+        self.inner.terminate = policy;
+
+        self
+    }
+
+    pub fn set_saved_pcode_raw(mut self, saved_pcode_raw: PathBuf) -> Self {
+        self.inner.saved_pcode_raw = Some(saved_pcode_raw);
+
+        self
+    }
 }
 
 impl Settings {
-    /// Returns a new settings object.
-    pub fn new(stage: Stage, verbose: Verbosity) -> Self {
-        Self {
-            stage,
-            verbose,
-            terminate: TerminationPolicy::default(),
-        }
+    pub fn get_saved_pcode_raw(&self) -> Option<PathBuf> {
+        self.saved_pcode_raw.clone()
     }
 
     /// Returns true iff the `stage` is being debugged.


### PR DESCRIPTION
It was observed that the Subregister Substitution may produce expressions that are semantically malformed. This happens when assignments are made to the lower bytes of a full register and this subregister has no special name.

It was noticed since evaluating a SUBPIECE expression of size zero over the PI abstract domain lead to panics (#469).

Note: The relevant patch is in the first commit. I snuck in some more debugging patches here ... just don't mind them :)

# Fix

The underlying issue is that when assigning to the lower bytes of registers the miss-translated pcode does not use special subregister names (or there simple are no such names), but rather used the full register with a smaller size. In those cases the old code would end up thinking that the subregister had the same size as the full register and the SUBPIECE expression over the old register value that is needed to build a sill-size assignment would end up being of size zero.

This is corrected by setting the register size of the full register to the size of the variable being assigned. If the register size is already correct, this should be a no-op. The fix is in the first commit.

# Examples

Here are some examples of previously malformed expressions that are corrected by this patch:

## `lxvd2x` on ppc64le

```
  0016e454 98 56     lxvd2x vs0,r28,r10
           1c 7c
                                   $U56800:8 = INT_ADD r28, r10
                                   f0 = LOAD ram($U56800:8)
                                   $U56900:8 = INT_ADD $U56800:8, 8:8
                                   vs0:8 = LOAD ram($U56900:8)
```

becomes

```
     DEF [instr_0016e454_0] $U5a300:8(temp) = (r28:8 + r10:8)
     DEF [instr_0016e454_1] loaded_value:8(temp) := Load from $U5a300:8(temp)
     DEF [instr_0016e454_1_cast_to_base] vs0:16 = (loaded_value:8(temp) Piece (vs0:16)[0-7])
     DEF [instr_0016e454_2] $U5a400:8(temp) = ($U5a300:8(temp) + 0x8:8)
     DEF [instr_0016e454_3] loaded_value:8(temp) := Load from $U5a400:8(temp)
-    DEF [instr_0016e454_3_cast_to_base] vs0:16 = ((vs0:16)[16-15] Piece loaded_value:8(temp))
+    DEF [instr_0016e454_3_cast_to_base] vs0:16 = ((vs0:16)[8-15] Piece loaded_value:8(temp))
```

## `cvt.s.L` on mips64el

```
  00117788 60 01     cvt.s.L       f5,f0
           a0 46
                                   f5:4 = INT2FLOAT f0

```

becomes

```
-    DEF [instr_0011778c_0] f5:8 = ((f5:8)[8-7] Piece ((f5:8)[0-3] FloatAdd (f5:8)[0-3]))
+    DEF [instr_0011778c_0] f5:8 = ((f5:8)[4-7] Piece ((f5:8)[0-3] FloatAdd (f5:8)[0-3]))
```

## `sel` on arm

```
  08000276 a3 fa     sel    r5,r3,r7
           87 f5
                     $Ub8680:1 = INT_EQUAL GE1, 1:1
                     $Ub8700:1 = INT_MULT $Ub8680:1, r3:1
                     $Ub8780:1 = INT_EQUAL GE1, 0:1
                     $Ub8800:1 = INT_MULT $Ub8780:1, r7:1
                     r5:1 = INT_ADD $Ub8700:1, $Ub8800:1
```

becomes

```
     DEF [instr_08000276_1] $Ub7900:1(temp) = $Ub7880:1(temp) * (r3:4)[0-0]
     DEF [instr_08000276_2] $Ub7980:1(temp) = (GE1:1 == 0x0:1)
     DEF [instr_08000276_3] $Ub7a00:1(temp) = $Ub7980:1(temp) * (r7:4)[0-0]
-    DEF [instr_08000276_4] r5:4 = ((r5:4)[4-3] Piece ($Ub7900:1(temp) + $Ub7a00:1(temp)))
+    DEF [instr_08000276_4] r5:4 = ((r5:4)[1-3] Piece ($Ub7900:1(temp) + $Ub7a00:1(temp)))
```

## Numbers

Here are the numbers of corrected lines for each program in our minimal test suite. All changes were manually verified to be correct.

```
| program  | arch        | occurrences |
|----------|-------------|------------|
| netfs.ko | amd64       | 0          |
| netfs.ko | arm64       | 0          |
| netfs.ko | armhf       | 0          |
| netfs.ko | mips32r2el  | 0          |
| netfs.ko | mips64r2el  | 0          |
| netfs.ko | powerpc64le | 0          |
| netfs.ko | x86         | 0          |
| ls       | amd64       | 0          |
| ls       | arm64       | 0          |
| ls       | armel       | 0          |
| ls       | armhf       | 0          |
| ls       | mips64el    | 54         |
| ls       | mipsel      | 0          |
| ls       | ppc64el     | 66         |
| ls       | x86         | 0          |
| readelf  | amd64       | 0          |
| readelf  | arm64       | 0          |
| readelf  | armel       | 0          |
| readelf  | armhf       | 0          |
| readelf  | mips64el    | 0          |
| readelf  | mipsel      | 0          |
| readelf  | ppc64el     | 31         |
| readelf  | x86         | 0          |
```