### PR TITLE
Fix address output to be hex

### DIFF
--- a/src/cwe_checker_lib/src/intermediate_representation/term.rs
+++ b/src/cwe_checker_lib/src/intermediate_representation/term.rs
@@ -45,7 +45,7 @@ pub struct TidAddress(Option<u64>);
 impl Display for TidAddress {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            Some(a) => write!(f, "{}", a),
+            Some(a) => write!(f, "{:x}", a),
             None => write!(f, "{}", Tid::UNKNOWN_ADDRESS),
         }
     }


### PR DESCRIPTION
Hi,

I observed that the output of cwe_checker return decimal addresses on the current "latest" branch. This behavior occurs on my system both with local installation as well as using the provided Dockerfile.

Rust: cargo 1.84.1 (66221abde 2024-11-19)
Ghidra: 11.2
Java: 21.0.8


I found a fix, though:
[term.rs:48](https://github.com/fkie-cad/cwe_checker/blame/3c042e6f0a795d32b9dca2591ef035b93281da0a/src/cwe_checker_lib/src/intermediate_representation/term.rs#L48) needs to be changed (see proposed commit).

